### PR TITLE
Set --junitxml when corresponding environment variable is available

### DIFF
--- a/python_pytest/pytest_shim.py
+++ b/python_pytest/pytest_shim.py
@@ -9,6 +9,9 @@ import pytest
 if __name__ == "__main__":
     pytest_args = ["--ignore=external"]
 
+    if os.environ.get("XML_OUTPUT_FILE"):
+        pytest_args.append("--junitxml={xml_output_file}".format(xml_output_file=os.environ.get("XML_OUTPUT_FILE")))
+
     if os.environ.get("TESTBRIDGE_TEST_ONLY"):
         # TestClass.test_fn -> TestClass::test_fn
         module_name = os.environ.get("TESTBRIDGE_TEST_ONLY").replace(".", "::")


### PR DESCRIPTION
This allows the xml output produced by `bazel test` to have richer per-test-case information rather than the default generated xml file, which just wraps the entire output as if it was a single test case. The environment variable is described on
https://bazel.build/reference/test-encyclopedia#initial-conditions.