### PR TITLE
Fix e2e/smoke tests

### DIFF
--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -1,28 +1,22 @@
 bazel_dep(name = "caseyduquettesc_rules_python_pytest", version = "0.0.0", dev_dependency = True, repo_name = "rules_python_pytest")
-bazel_dep(name = "bazel_skylib", version = "1.3.0", dev_dependency = True)
-bazel_dep(name = "rules_python", version = "0.19.0", dev_dependency = True)
+bazel_dep(name = "bazel_skylib", version = "1.4.2", dev_dependency = True)
+bazel_dep(name = "rules_python", version = "0.24.0", dev_dependency = True)
 
 local_path_override(
     module_name = "caseyduquettesc_rules_python_pytest",
     path = "../..",
 )
 
-# Pretty much copied from https://github.com/bazelbuild/rules_python/releases/tag/0.17.3
-python = use_extension("@rules_python//python:extensions.bzl", "python")
+# Pretty much copied from https://github.com/bazelbuild/rules_python/releases/tag/0.24.0
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
-    name = "python3_9",
     is_default = True,
     python_version = "3.9",
 )
-use_repo(python, "python3_9_toolchains")
 
-register_toolchains(
-    "@python3_9_toolchains//:all",
-)
-
-pip = use_extension("@rules_python//python:extensions.bzl", "pip")
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
-    name = "pip",
+    hub_name = "pip",
     requirements_lock = "//:requirements.txt",
 )
 use_repo(pip, "pip")

--- a/e2e/smoke/MODULE.bazel.lock
+++ b/e2e/smoke/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 1,
-  "moduleFileHash": "5b670bf36bc86cbc5592fe210c7b86bb90b503c7e7e76100009c9d496f413d81",
+  "moduleFileHash": "6f01102ac1d58119666d352eefb4f1af64b8512e2dfe8df460e9d27c566f085b",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -23,12 +23,10 @@
       "key": "<root>",
       "repoName": "",
       "executionPlatformsToRegister": [],
-      "toolchainsToRegister": [
-        "@python3_9_toolchains//:all"
-      ],
+      "toolchainsToRegister": [],
       "extensionUsages": [
         {
-          "extensionBzlFile": "@rules_python//python:extensions.bzl",
+          "extensionBzlFile": "@rules_python//python/extensions:python.bzl",
           "extensionName": "python",
           "usingModule": "<root>",
           "location": {
@@ -36,14 +34,12 @@
             "line": 11,
             "column": 23
           },
-          "imports": {
-            "python3_9_toolchains": "python3_9_toolchains"
-          },
+          "imports": {},
           "devImports": [],
           "tags": [
             {
               "tagName": "toolchain",
-              "attributeValues": {"name":"--python3_9","python_version":"--3.9","is_default":true},
+              "attributeValues": {"python_version":"--3.9","is_default":true},
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
@@ -56,12 +52,12 @@
           "hasNonDevUseExtension": true
         },
         {
-          "extensionBzlFile": "@rules_python//python:extensions.bzl",
+          "extensionBzlFile": "@rules_python//python/extensions:pip.bzl",
           "extensionName": "pip",
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 23,
+            "line": 17,
             "column": 20
           },
           "imports": {
@@ -71,11 +67,11 @@
           "tags": [
             {
               "tagName": "parse",
-              "attributeValues": {"name":"--pip","requirements_lock":"--//:requirements.txt"},
+              "attributeValues": {"hub_name":"--pip","requirements_lock":"--//:requirements.txt"},
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 24,
+                "line": 18,
                 "column": 10
               }
             }
@@ -89,7 +85,7 @@
         "local_config_platform": "local_config_platform@_",
         "rules_python_pytest": "caseyduquettesc_rules_python_pytest@_",
         "bazel_skylib": "bazel_skylib@1.4.2",
-        "rules_python": "rules_python@0.19.0"
+        "rules_python": "rules_python@0.24.0"
       }
     },
     "bazel_tools@_": {
@@ -219,7 +215,7 @@
         "rules_java": "rules_java@5.5.0",
         "rules_license": "rules_license@0.0.3",
         "rules_proto": "rules_proto@5.3.0-21.7",
-        "rules_python": "rules_python@0.19.0",
+        "rules_python": "rules_python@0.24.0",
         "platforms": "platforms@0.0.5",
         "com_google_protobuf": "protobuf@21.7",
         "zlib": "zlib@1.2.13"
@@ -251,7 +247,7 @@
         "local_config_platform": "local_config_platform@_",
         "bazel_skylib": "bazel_skylib@1.4.2",
         "platforms": "platforms@0.0.5",
-        "rules_python": "rules_python@0.19.0"
+        "rules_python": "rules_python@0.24.0"
       }
     },
     "bazel_skylib@1.4.2": {
@@ -276,20 +272,22 @@
         "attributes": {"name":"--bazel_skylib~1.4.2","urls":["--https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz"],"integrity":"--sha256-Zv/ZMVZlv6r8lrUiePV8fi3Qn17eJ56m05sr5HHn46o=","strip_prefix":"--","remote_patches":{},"remote_patch_strip":0}
       }
     },
-    "rules_python@0.19.0": {
+    "rules_python@0.24.0": {
       "name": "rules_python",
-      "version": "0.19.0",
-      "key": "rules_python@0.19.0",
+      "version": "0.24.0",
+      "key": "rules_python@0.24.0",
       "repoName": "rules_python",
       "executionPlatformsToRegister": [],
-      "toolchainsToRegister": [],
+      "toolchainsToRegister": [
+        "@pythons_hub//:all"
+      ],
       "extensionUsages": [
         {
-          "extensionBzlFile": "@rules_python//python:extensions.bzl",
+          "extensionBzlFile": "@rules_python//python/extensions/private:internal_deps.bzl",
           "extensionName": "internal_deps",
-          "usingModule": "rules_python@0.19.0",
+          "usingModule": "rules_python@0.24.0",
           "location": {
-            "file": "https://bcr.bazel.build/modules/rules_python/0.19.0/MODULE.bazel",
+            "file": "https://bcr.bazel.build/modules/rules_python/0.24.0/MODULE.bazel",
             "line": 14,
             "column": 30
           },
@@ -307,22 +305,7 @@
             "pypi__setuptools": "pypi__setuptools",
             "pypi__tomli": "pypi__tomli",
             "pypi__wheel": "pypi__wheel",
-            "pypi__zipp": "pypi__zipp",
-            "pypi__coverage_cp310_aarch64-apple-darwin": "pypi__coverage_cp310_aarch64-apple-darwin",
-            "pypi__coverage_cp310_aarch64-unknown-linux-gnu": "pypi__coverage_cp310_aarch64-unknown-linux-gnu",
-            "pypi__coverage_cp310_x86_64-apple-darwin": "pypi__coverage_cp310_x86_64-apple-darwin",
-            "pypi__coverage_cp310_x86_64-unknown-linux-gnu": "pypi__coverage_cp310_x86_64-unknown-linux-gnu",
-            "pypi__coverage_cp311_aarch64-unknown-linux-gnu": "pypi__coverage_cp311_aarch64-unknown-linux-gnu",
-            "pypi__coverage_cp311_x86_64-apple-darwin": "pypi__coverage_cp311_x86_64-apple-darwin",
-            "pypi__coverage_cp311_x86_64-unknown-linux-gnu": "pypi__coverage_cp311_x86_64-unknown-linux-gnu",
-            "pypi__coverage_cp38_aarch64-apple-darwin": "pypi__coverage_cp38_aarch64-apple-darwin",
-            "pypi__coverage_cp38_aarch64-unknown-linux-gnu": "pypi__coverage_cp38_aarch64-unknown-linux-gnu",
-            "pypi__coverage_cp38_x86_64-apple-darwin": "pypi__coverage_cp38_x86_64-apple-darwin",
-            "pypi__coverage_cp38_x86_64-unknown-linux-gnu": "pypi__coverage_cp38_x86_64-unknown-linux-gnu",
-            "pypi__coverage_cp39_aarch64-apple-darwin": "pypi__coverage_cp39_aarch64-apple-darwin",
-            "pypi__coverage_cp39_aarch64-unknown-linux-gnu": "pypi__coverage_cp39_aarch64-unknown-linux-gnu",
-            "pypi__coverage_cp39_x86_64-apple-darwin": "pypi__coverage_cp39_x86_64-apple-darwin",
-            "pypi__coverage_cp39_x86_64-unknown-linux-gnu": "pypi__coverage_cp39_x86_64-unknown-linux-gnu"
+            "pypi__zipp": "pypi__zipp"
           },
           "devImports": [],
           "tags": [
@@ -331,9 +314,37 @@
               "attributeValues": {},
               "devDependency": false,
               "location": {
-                "file": "https://bcr.bazel.build/modules/rules_python/0.19.0/MODULE.bazel",
+                "file": "https://bcr.bazel.build/modules/rules_python/0.24.0/MODULE.bazel",
                 "line": 15,
                 "column": 22
+              }
+            }
+          ],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        },
+        {
+          "extensionBzlFile": "@rules_python//python/extensions:python.bzl",
+          "extensionName": "python",
+          "usingModule": "rules_python@0.24.0",
+          "location": {
+            "file": "https://bcr.bazel.build/modules/rules_python/0.24.0/MODULE.bazel",
+            "line": 36,
+            "column": 23
+          },
+          "imports": {
+            "pythons_hub": "pythons_hub"
+          },
+          "devImports": [],
+          "tags": [
+            {
+              "tagName": "toolchain",
+              "attributeValues": {"is_default":true,"python_version":"--3.11"},
+              "devDependency": false,
+              "location": {
+                "file": "https://bcr.bazel.build/modules/rules_python/0.24.0/MODULE.bazel",
+                "line": 42,
+                "column": 17
               }
             }
           ],
@@ -352,7 +363,7 @@
       "repoSpec": {
         "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
-        "attributes": {"name":"--rules_python~0.19.0","urls":["--https://github.com/bazelbuild/rules_python/releases/download/0.19.0/rules_python-0.19.0.tar.gz"],"integrity":"--sha256-/8e4d8lUE8gr/VSCwBftz3WaYlDYsk6C9B88i42eKH4=","strip_prefix":"--rules_python-0.19.0","remote_patches":{"--https://bcr.bazel.build/modules/rules_python/0.19.0/patches/module_dot_bazel_version.patch":"--sha256-oRg4TxtZRlGGiadzPEwt2MtofP/JpBhE90bRVDRaazA="},"remote_patch_strip":0}
+        "attributes": {"name":"--rules_python~0.24.0","urls":["--https://github.com/bazelbuild/rules_python/releases/download/0.24.0/rules_python-0.24.0.tar.gz"],"integrity":"--sha256-CoADsEQpTXhArH2dc+7wXWzraC11FngaTsYu6zRwJXg=","strip_prefix":"--rules_python-0.24.0","remote_patches":{"--https://bcr.bazel.build/modules/rules_python/0.24.0/patches/module_dot_bazel_version.patch":"--sha256-cz8Rx8aNLvYvSpiVWk8umcsBy6jAAC0YwU42zj1cNlU="},"remote_patch_strip":0}
       }
     },
     "rules_cc@0.0.2": {
@@ -571,7 +582,7 @@
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_",
         "bazel_skylib": "bazel_skylib@1.4.2",
-        "rules_python": "rules_python@0.19.0",
+        "rules_python": "rules_python@0.24.0",
         "rules_cc": "rules_cc@0.0.2",
         "rules_proto": "rules_proto@5.3.0-21.7",
         "rules_java": "rules_java@5.5.0",
@@ -617,7 +628,7 @@
       "deps": {
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_",
-        "rules_python": "rules_python@0.19.0",
+        "rules_python": "rules_python@0.24.0",
         "bazel_skylib": "bazel_skylib@1.4.2",
         "rules_license": "rules_license@0.0.3"
       },
@@ -779,88 +790,10 @@
     }
   },
   "moduleExtensions": {
-    "@rules_python~0.19.0//python:extensions.bzl%python": {
-      "bzlTransitiveDigest": "TdVE2rMTdBY8oViD7RsK9I7CumQDlB3WsrusmODrLVQ=",
-      "generatedRepoSpecs": {
-        "python3_9_aarch64-unknown-linux-gnu": {
-          "bzlFile": "@@rules_python~0.19.0//python:repositories.bzl",
-          "ruleClassName": "python_repository",
-          "attributes": {"name":"--rules_python~0.19.0~python~python3_9_aarch64-unknown-linux-gnu","sha256":"--1ba520c0db431c84305677f56eb9a4254f5097430ed443e92fc8617f8fba973d","patches":[],"platform":"--aarch64-unknown-linux-gnu","python_version":"--3.9.16","release_filename":"--20230116/cpython-3.9.16+20230116-aarch64-unknown-linux-gnu-install_only.tar.gz","url":"--https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.9.16+20230116-aarch64-unknown-linux-gnu-install_only.tar.gz","distutils":null,"distutils_content":"--","strip_prefix":"--python","coverage_tool":null}
-        },
-        "python3_9_x86_64-pc-windows-msvc": {
-          "bzlFile": "@@rules_python~0.19.0//python:repositories.bzl",
-          "ruleClassName": "python_repository",
-          "attributes": {"name":"--rules_python~0.19.0~python~python3_9_x86_64-pc-windows-msvc","sha256":"--5274afd6b7ff2bddbd8306385ffb2336764b0e58535db968daeac656246f59a8","patches":[],"platform":"--x86_64-pc-windows-msvc","python_version":"--3.9.16","release_filename":"--20230116/cpython-3.9.16+20230116-x86_64-pc-windows-msvc-shared-install_only.tar.gz","url":"--https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.9.16+20230116-x86_64-pc-windows-msvc-shared-install_only.tar.gz","distutils":null,"distutils_content":"--","strip_prefix":"--python","coverage_tool":null}
-        },
-        "python3_9_x86_64-unknown-linux-gnu": {
-          "bzlFile": "@@rules_python~0.19.0//python:repositories.bzl",
-          "ruleClassName": "python_repository",
-          "attributes": {"name":"--rules_python~0.19.0~python~python3_9_x86_64-unknown-linux-gnu","sha256":"--7ba397787932393e65fc2fb9fcfabf54f2bb6751d5da2b45913cb25b2d493758","patches":[],"platform":"--x86_64-unknown-linux-gnu","python_version":"--3.9.16","release_filename":"--20230116/cpython-3.9.16+20230116-x86_64-unknown-linux-gnu-install_only.tar.gz","url":"--https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.9.16+20230116-x86_64-unknown-linux-gnu-install_only.tar.gz","distutils":null,"distutils_content":"--","strip_prefix":"--python","coverage_tool":null}
-        },
-        "python3_9_aarch64-apple-darwin": {
-          "bzlFile": "@@rules_python~0.19.0//python:repositories.bzl",
-          "ruleClassName": "python_repository",
-          "attributes": {"name":"--rules_python~0.19.0~python~python3_9_aarch64-apple-darwin","sha256":"--d732d212d42315ac27c6da3e0b69636737a8d72086c980daf844344c010cab80","patches":[],"platform":"--aarch64-apple-darwin","python_version":"--3.9.16","release_filename":"--20230116/cpython-3.9.16+20230116-aarch64-apple-darwin-install_only.tar.gz","url":"--https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.9.16+20230116-aarch64-apple-darwin-install_only.tar.gz","distutils":null,"distutils_content":"--","strip_prefix":"--python","coverage_tool":null}
-        },
-        "python3_9_x86_64-apple-darwin": {
-          "bzlFile": "@@rules_python~0.19.0//python:repositories.bzl",
-          "ruleClassName": "python_repository",
-          "attributes": {"name":"--rules_python~0.19.0~python~python3_9_x86_64-apple-darwin","sha256":"--3948384af5e8d4ee7e5ccc648322b99c1c5cf4979954ed5e6b3382c69d6db71e","patches":[],"platform":"--x86_64-apple-darwin","python_version":"--3.9.16","release_filename":"--20230116/cpython-3.9.16+20230116-x86_64-apple-darwin-install_only.tar.gz","url":"--https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.9.16+20230116-x86_64-apple-darwin-install_only.tar.gz","distutils":null,"distutils_content":"--","strip_prefix":"--python","coverage_tool":null}
-        },
-        "python3_9": {
-          "bzlFile": "@@rules_python~0.19.0//python/private:toolchains_repo.bzl",
-          "ruleClassName": "toolchain_aliases",
-          "attributes": {"name":"--rules_python~0.19.0~python~python3_9","python_version":"--3.9.16","user_repository_name":"--python3_9"}
-        },
-        "python3_9_toolchains": {
-          "bzlFile": "@@rules_python~0.19.0//python/private:toolchains_repo.bzl",
-          "ruleClassName": "toolchains_repo",
-          "attributes": {"name":"--rules_python~0.19.0~python~python3_9_toolchains","python_version":"--3.9.16","set_python_version_constraint":false,"user_repository_name":"--python3_9"}
-        }
-      }
-    },
-    "@rules_python~0.19.0//python:extensions.bzl%pip": {
-      "bzlTransitiveDigest": "TdVE2rMTdBY8oViD7RsK9I7CumQDlB3WsrusmODrLVQ=",
-      "generatedRepoSpecs": {
-        "pip_iniconfig": {
-          "bzlFile": "@@rules_python~0.19.0//python/pip_install:pip_repository.bzl",
-          "ruleClassName": "whl_library",
-          "attributes": {"name":"--rules_python~0.19.0~pip~pip_iniconfig","requirement":"--iniconfig==2.0.0     --hash=sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3     --hash=sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374","repo":"--pip","repo_prefix":"--pip_","annotation":null,"python_interpreter":"--","python_interpreter_target":null,"quiet":true,"timeout":600,"isolated":true,"extra_pip_args":[],"download_only":false,"pip_data_exclude":[],"enable_implicit_namespace_pkgs":false,"environment":{}}
-        },
-        "pip_packaging": {
-          "bzlFile": "@@rules_python~0.19.0//python/pip_install:pip_repository.bzl",
-          "ruleClassName": "whl_library",
-          "attributes": {"name":"--rules_python~0.19.0~pip~pip_packaging","requirement":"--packaging==23.1     --hash=sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61     --hash=sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f","repo":"--pip","repo_prefix":"--pip_","annotation":null,"python_interpreter":"--","python_interpreter_target":null,"quiet":true,"timeout":600,"isolated":true,"extra_pip_args":[],"download_only":false,"pip_data_exclude":[],"enable_implicit_namespace_pkgs":false,"environment":{}}
-        },
-        "pip": {
-          "bzlFile": "@@rules_python~0.19.0//python/pip_install:pip_repository.bzl",
-          "ruleClassName": "pip_repository_bzlmod",
-          "attributes": {"name":"--rules_python~0.19.0~pip~pip","requirements_lock":"@@//:requirements.txt"}
-        },
-        "pip_exceptiongroup": {
-          "bzlFile": "@@rules_python~0.19.0//python/pip_install:pip_repository.bzl",
-          "ruleClassName": "whl_library",
-          "attributes": {"name":"--rules_python~0.19.0~pip~pip_exceptiongroup","requirement":"--exceptiongroup==1.1.2     --hash=sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5     --hash=sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f","repo":"--pip","repo_prefix":"--pip_","annotation":null,"python_interpreter":"--","python_interpreter_target":null,"quiet":true,"timeout":600,"isolated":true,"extra_pip_args":[],"download_only":false,"pip_data_exclude":[],"enable_implicit_namespace_pkgs":false,"environment":{}}
-        },
-        "pip_pluggy": {
-          "bzlFile": "@@rules_python~0.19.0//python/pip_install:pip_repository.bzl",
-          "ruleClassName": "whl_library",
-          "attributes": {"name":"--rules_python~0.19.0~pip~pip_pluggy","requirement":"--pluggy==1.2.0     --hash=sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849     --hash=sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3","repo":"--pip","repo_prefix":"--pip_","annotation":null,"python_interpreter":"--","python_interpreter_target":null,"quiet":true,"timeout":600,"isolated":true,"extra_pip_args":[],"download_only":false,"pip_data_exclude":[],"enable_implicit_namespace_pkgs":false,"environment":{}}
-        },
-        "pip_pytest": {
-          "bzlFile": "@@rules_python~0.19.0//python/pip_install:pip_repository.bzl",
-          "ruleClassName": "whl_library",
-          "attributes": {"name":"--rules_python~0.19.0~pip~pip_pytest","requirement":"--pytest==7.3.2     --hash=sha256:cdcbd012c9312258922f8cd3f1b62a6580fdced17db6014896053d47cddf9295     --hash=sha256:ee990a3cc55ba808b80795a79944756f315c67c12b56abd3ac993a7b8c17030b","repo":"--pip","repo_prefix":"--pip_","annotation":null,"python_interpreter":"--","python_interpreter_target":null,"quiet":true,"timeout":600,"isolated":true,"extra_pip_args":[],"download_only":false,"pip_data_exclude":[],"enable_implicit_namespace_pkgs":false,"environment":{}}
-        },
-        "pip_tomli": {
-          "bzlFile": "@@rules_python~0.19.0//python/pip_install:pip_repository.bzl",
-          "ruleClassName": "whl_library",
-          "attributes": {"name":"--rules_python~0.19.0~pip~pip_tomli","requirement":"--tomli==2.0.1     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f","repo":"--pip","repo_prefix":"--pip_","annotation":null,"python_interpreter":"--","python_interpreter_target":null,"quiet":true,"timeout":600,"isolated":true,"extra_pip_args":[],"download_only":false,"pip_data_exclude":[],"enable_implicit_namespace_pkgs":false,"environment":{}}
-        }
-      }
-    },
     "@bazel_tools//tools/sh:sh_configure.bzl%sh_configure_extension": {
       "bzlTransitiveDigest": "hp4NgmNjEg5+xgvzfh6L83bt9/aiiWETuNpwNuF1MSU=",
+      "accumulatedFileDigests": {},
+      "envVariables": {},
       "generatedRepoSpecs": {
         "local_config_sh": {
           "bzlFile": "@@bazel_tools//tools/sh:sh_configure.bzl",
@@ -871,6 +804,8 @@
     },
     "@bazel_tools//tools/cpp:cc_configure.bzl%cc_configure_extension": {
       "bzlTransitiveDigest": "fX+NTqVY9jebrhWZSjm+R2r4sMbV1U3pvP90DKmouSg=",
+      "accumulatedFileDigests": {},
+      "envVariables": {},
       "generatedRepoSpecs": {
         "local_config_cc": {
           "bzlFile": "@@bazel_tools//tools/cpp:cc_configure.bzl",
@@ -886,6 +821,8 @@
     },
     "@rules_java~5.5.0//java:extensions.bzl%toolchains": {
       "bzlTransitiveDigest": "IVTttRaqn26iAvJN4qehdM+OxbrjZDF3SRPyI2lokXk=",
+      "accumulatedFileDigests": {},
+      "envVariables": {},
       "generatedRepoSpecs": {
         "remotejdk19_macos_aarch64_toolchain_config_repo": {
           "bzlFile": "@@rules_java~5.5.0//toolchains:remote_java_repository.bzl",
@@ -1096,6 +1033,8 @@
     },
     "@rules_cc~0.0.2//cc:extensions.bzl%cc_configure": {
       "bzlTransitiveDigest": "MxlRT9mERSSlHP4U9xvwnAp8XZNE0WlEE1QudRdeQog=",
+      "accumulatedFileDigests": {},
+      "envVariables": {},
       "generatedRepoSpecs": {
         "local_config_cc": {
           "bzlFile": "@@rules_cc~0.0.2//cc/private/toolchain:cc_configure.bzl",
@@ -1116,6 +1055,8 @@
     },
     "@bazel_tools//tools/osx:xcode_configure.bzl%xcode_configure_extension": {
       "bzlTransitiveDigest": "OmamqKJsiE8WH/LST0ioVROxC7R/MdakCNW9DSPS5/U=",
+      "accumulatedFileDigests": {},
+      "envVariables": {},
       "generatedRepoSpecs": {
         "local_config_xcode": {
           "bzlFile": "@@bazel_tools//tools/osx:xcode_configure.bzl",
@@ -1124,153 +1065,674 @@
         }
       }
     },
-    "@rules_python~0.19.0//python:extensions.bzl%internal_deps": {
-      "bzlTransitiveDigest": "TdVE2rMTdBY8oViD7RsK9I7CumQDlB3WsrusmODrLVQ=",
+    "@bazel_tools//tools/android:android_extensions.bzl%remote_android_tools_extensions": {
+      "bzlTransitiveDigest": "4+Dj2H7maLh8JtpJKiuaI7PSXiIZw6oWX9xsVhnJ5DU=",
+      "accumulatedFileDigests": {},
+      "envVariables": {},
       "generatedRepoSpecs": {
-        "pypi__coverage_cp39_aarch64-apple-darwin": {
+        "android_tools": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
           "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__coverage_cp39_aarch64-apple-darwin","build_file_content":"--\nfilegroup(\n    name = \"coverage\",\n    srcs = [\"coverage/__main__.py\"],\n    data = glob([\"coverage/*.py\", \"coverage/**/*.py\", \"coverage/*.so\"]),\n    visibility = [\"//visibility:public\"],\n)\n    ","patch_args":["---p1"],"patches":["@@rules_python~0.19.0//python/private:coverage.patch"],"sha256":"--95203854f974e07af96358c0b261f1048d8e1083f2de9b1c565e1be4a3a48cfc","type":"--zip","urls":["--https://files.pythonhosted.org/packages/63/e9/f23e8664ec4032d7802a1cf920853196bcbdce7b56408e3efe1b2da08f3c/coverage-6.5.0-cp39-cp39-macosx_11_0_arm64.whl"]}
+          "attributes": {"name":"--bazel_tools~remote_android_tools_extensions~android_tools","sha256":"--1afa4b7e13c82523c8b69e87f8d598c891ec7e2baa41d9e24e08becd723edb4d","url":"--https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.27.0.tar.gz"}
         },
-        "pypi__coverage_cp38_aarch64-unknown-linux-gnu": {
+        "android_gmaven_r8": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_jar",
+          "attributes": {"name":"--bazel_tools~remote_android_tools_extensions~android_gmaven_r8","sha256":"--ab1379835c7d3e5f21f80347c3c81e2f762e0b9b02748ae5232c3afa14adf702","url":"--https://maven.google.com/com/android/tools/r8/8.0.40/r8-8.0.40.jar"}
+        }
+      }
+    },
+    "@bazel_tools//tools/test:extensions.bzl%remote_coverage_tools_extension": {
+      "bzlTransitiveDigest": "IWFtZ+6M0WGmNpfnHZMxnVFSDZ6pRTEWt7jixp7XffQ=",
+      "accumulatedFileDigests": {},
+      "envVariables": {},
+      "generatedRepoSpecs": {
+        "remote_coverage_tools": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
           "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__coverage_cp38_aarch64-unknown-linux-gnu","build_file_content":"--\nfilegroup(\n    name = \"coverage\",\n    srcs = [\"coverage/__main__.py\"],\n    data = glob([\"coverage/*.py\", \"coverage/**/*.py\", \"coverage/*.so\"]),\n    visibility = [\"//visibility:public\"],\n)\n    ","patch_args":["---p1"],"patches":["@@rules_python~0.19.0//python/private:coverage.patch"],"sha256":"--6c4459b3de97b75e3bd6b7d4b7f0db13f17f504f3d13e2a7c623786289dd670e","type":"--zip","urls":["--https://files.pythonhosted.org/packages/40/3b/cd68cb278c4966df00158811ec1e357b9a7d132790c240fc65da57e10013/coverage-6.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"]}
-        },
-        "pypi__pip_tools": {
+          "attributes": {"name":"--bazel_tools~remote_coverage_tools_extension~remote_coverage_tools","sha256":"--7006375f6756819b7013ca875eab70a541cf7d89142d9c511ed78ea4fefa38af","urls":["--https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.6.zip"]}
+        }
+      }
+    },
+    "@rules_jvm_external~4.4.2//:non-module-deps.bzl%non_module_deps": {
+      "bzlTransitiveDigest": "QlnkwH7xmrau2+KLjoV5wWr0r3Ne+JfXhrHUVpwVloQ=",
+      "accumulatedFileDigests": {},
+      "envVariables": {},
+      "generatedRepoSpecs": {
+        "io_bazel_rules_kotlin": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
           "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__pip_tools","url":"--https://files.pythonhosted.org/packages/5e/e8/f6d7d1847c7351048da870417724ace5c4506e816b38db02f4d7c675c189/pip_tools-6.12.1-py3-none-any.whl","sha256":"--f0c0c0ec57b58250afce458e2e6058b1f30a4263db895b7d72fd6311bf1dc6f7","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
-        },
-        "pypi__coverage_cp310_x86_64-unknown-linux-gnu": {
+          "attributes": {"name":"--rules_jvm_external~4.4.2~non_module_deps~io_bazel_rules_kotlin","sha256":"--946747acdbeae799b085d12b240ec346f775ac65236dfcf18aa0cd7300f6de78","urls":["--https://github.com/bazelbuild/rules_kotlin/releases/download/v1.7.0-RC-2/rules_kotlin_release.tgz"]}
+        }
+      }
+    },
+    "@rules_jvm_external~4.4.2//:extensions.bzl%maven": {
+      "bzlTransitiveDigest": "istmyWP0h8op1Y4uAZZpKSZR6IiKJFC+0DDHxSqZeZU=",
+      "accumulatedFileDigests": {},
+      "envVariables": {},
+      "generatedRepoSpecs": {
+        "org_slf4j_slf4j_api_1_7_30": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-          "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__coverage_cp310_x86_64-unknown-linux-gnu","build_file_content":"--\nfilegroup(\n    name = \"coverage\",\n    srcs = [\"coverage/__main__.py\"],\n    data = glob([\"coverage/*.py\", \"coverage/**/*.py\", \"coverage/*.so\"]),\n    visibility = [\"//visibility:public\"],\n)\n    ","patch_args":["---p1"],"patches":["@@rules_python~0.19.0//python/private:coverage.patch"],"sha256":"--af4fffaffc4067232253715065e30c5a7ec6faac36f8fc8d6f64263b15f74db0","type":"--zip","urls":["--https://files.pythonhosted.org/packages/3c/7d/d5211ea782b193ab8064b06dc0cc042cf1a4ca9c93a530071459172c550f/coverage-6.5.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"]}
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~org_slf4j_slf4j_api_1_7_30","sha256":"--cdba07964d1bb40a0761485c6b1e8c2f8fd9eb1d19c53928ac0d7f9510105c57","urls":["--https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.jar","--https://maven.google.com/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.jar"}
         },
-        "pypi__coverage_cp311_x86_64-apple-darwin": {
+        "com_google_api_grpc_proto_google_common_protos_2_0_1": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-          "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__coverage_cp311_x86_64-apple-darwin","build_file_content":"--\nfilegroup(\n    name = \"coverage\",\n    srcs = [\"coverage/__main__.py\"],\n    data = glob([\"coverage/*.py\", \"coverage/**/*.py\", \"coverage/*.so\"]),\n    visibility = [\"//visibility:public\"],\n)\n    ","patch_args":["---p1"],"patches":["@@rules_python~0.19.0//python/private:coverage.patch"],"sha256":"--4a5375e28c5191ac38cca59b38edd33ef4cc914732c916f2929029b4bfb50795","type":"--zip","urls":["--https://files.pythonhosted.org/packages/50/cf/455930004231fa87efe8be06d13512f34e070ddfee8b8bf5a050cdc47ab3/coverage-6.5.0-cp311-cp311-macosx_10_9_x86_64.whl"]}
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_api_grpc_proto_google_common_protos_2_0_1","sha256":"--5ce71656118618731e34a5d4c61aa3a031be23446dc7de8b5a5e77b66ebcd6ef","urls":["--https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/2.0.1/proto-google-common-protos-2.0.1.jar","--https://maven.google.com/com/google/api/grpc/proto-google-common-protos/2.0.1/proto-google-common-protos-2.0.1.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/2.0.1/proto-google-common-protos-2.0.1.jar"}
         },
-        "pypi__coverage_cp310_aarch64-unknown-linux-gnu": {
+        "com_google_api_gax_1_60_0": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-          "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__coverage_cp310_aarch64-unknown-linux-gnu","build_file_content":"--\nfilegroup(\n    name = \"coverage\",\n    srcs = [\"coverage/__main__.py\"],\n    data = glob([\"coverage/*.py\", \"coverage/**/*.py\", \"coverage/*.so\"]),\n    visibility = [\"//visibility:public\"],\n)\n    ","patch_args":["---p1"],"patches":["@@rules_python~0.19.0//python/private:coverage.patch"],"sha256":"--b4a5be1748d538a710f87542f22c2cad22f80545a847ad91ce45e77417293eb4","type":"--zip","urls":["--https://files.pythonhosted.org/packages/15/b0/3639d84ee8a900da0cf6450ab46e22517e4688b6cec0ba8ab6f8166103a2/coverage-6.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"]}
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_api_gax_1_60_0","sha256":"--02f37d4ff1a7b8d71dff8064cf9568aa4f4b61bcc4485085d16130f32afa5a79","urls":["--https://repo1.maven.org/maven2/com/google/api/gax/1.60.0/gax-1.60.0.jar","--https://maven.google.com/com/google/api/gax/1.60.0/gax-1.60.0.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/api/gax/1.60.0/gax-1.60.0.jar"}
         },
-        "pypi__coverage_cp39_aarch64-unknown-linux-gnu": {
+        "com_google_guava_failureaccess_1_0_1": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-          "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__coverage_cp39_aarch64-unknown-linux-gnu","build_file_content":"--\nfilegroup(\n    name = \"coverage\",\n    srcs = [\"coverage/__main__.py\"],\n    data = glob([\"coverage/*.py\", \"coverage/**/*.py\", \"coverage/*.so\"]),\n    visibility = [\"//visibility:public\"],\n)\n    ","patch_args":["---p1"],"patches":["@@rules_python~0.19.0//python/private:coverage.patch"],"sha256":"--b9023e237f4c02ff739581ef35969c3739445fb059b060ca51771e69101efffe","type":"--zip","urls":["--https://files.pythonhosted.org/packages/18/95/27f80dcd8273171b781a19d109aeaed7f13d78ef6d1e2f7134a5826fd1b4/coverage-6.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"]}
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_guava_failureaccess_1_0_1","sha256":"--a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26","urls":["--https://repo1.maven.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar","--https://maven.google.com/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar"}
         },
-        "pypi__coverage_cp310_aarch64-apple-darwin": {
+        "commons_logging_commons_logging_1_2": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-          "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__coverage_cp310_aarch64-apple-darwin","build_file_content":"--\nfilegroup(\n    name = \"coverage\",\n    srcs = [\"coverage/__main__.py\"],\n    data = glob([\"coverage/*.py\", \"coverage/**/*.py\", \"coverage/*.so\"]),\n    visibility = [\"//visibility:public\"],\n)\n    ","patch_args":["---p1"],"patches":["@@rules_python~0.19.0//python/private:coverage.patch"],"sha256":"--784f53ebc9f3fd0e2a3f6a78b2be1bd1f5575d7863e10c6e12504f240fd06660","type":"--zip","urls":["--https://files.pythonhosted.org/packages/89/a2/cbf599e50bb4be416e0408c4cf523c354c51d7da39935461a9687e039481/coverage-6.5.0-cp310-cp310-macosx_11_0_arm64.whl"]}
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~commons_logging_commons_logging_1_2","sha256":"--daddea1ea0be0f56978ab3006b8ac92834afeefbd9b7e4e6316fca57df0fa636","urls":["--https://repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.jar","--https://maven.google.com/commons-logging/commons-logging/1.2/commons-logging-1.2.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.jar"}
         },
-        "pypi__pip": {
+        "com_google_http_client_google_http_client_appengine_1_38_0": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-          "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__pip","url":"--https://files.pythonhosted.org/packages/09/bd/2410905c76ee14c62baf69e3f4aa780226c1bbfc9485731ad018e35b0cb5/pip-22.3.1-py3-none-any.whl","sha256":"--908c78e6bc29b676ede1c4d57981d490cb892eb45cd8c214ab6298125119e077","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_http_client_google_http_client_appengine_1_38_0","sha256":"--f97b495fd97ac3a3d59099eb2b55025f4948230da15a076f189b9cff37c6b4d2","urls":["--https://repo1.maven.org/maven2/com/google/http-client/google-http-client-appengine/1.38.0/google-http-client-appengine-1.38.0.jar","--https://maven.google.com/com/google/http-client/google-http-client-appengine/1.38.0/google-http-client-appengine-1.38.0.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/http-client/google-http-client-appengine/1.38.0/google-http-client-appengine-1.38.0.jar"}
         },
-        "pypi__coverage_cp38_x86_64-apple-darwin": {
+        "com_google_cloud_google_cloud_storage_1_113_4": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-          "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__coverage_cp38_x86_64-apple-darwin","build_file_content":"--\nfilegroup(\n    name = \"coverage\",\n    srcs = [\"coverage/__main__.py\"],\n    data = glob([\"coverage/*.py\", \"coverage/**/*.py\", \"coverage/*.so\"]),\n    visibility = [\"//visibility:public\"],\n)\n    ","patch_args":["---p1"],"patches":["@@rules_python~0.19.0//python/private:coverage.patch"],"sha256":"--d900bb429fdfd7f511f868cedd03a6bbb142f3f9118c09b99ef8dc9bf9643c3c","type":"--zip","urls":["--https://files.pythonhosted.org/packages/05/63/a789b462075395d34f8152229dccf92b25ca73eac05b3f6cd75fa5017095/coverage-6.5.0-cp38-cp38-macosx_10_9_x86_64.whl"]}
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_cloud_google_cloud_storage_1_113_4","sha256":"--796833e9bdab80c40bbc820e65087eb8f28c6bfbca194d2e3e00d98cb5bc55d6","urls":["--https://repo1.maven.org/maven2/com/google/cloud/google-cloud-storage/1.113.4/google-cloud-storage-1.113.4.jar","--https://maven.google.com/com/google/cloud/google-cloud-storage/1.113.4/google-cloud-storage-1.113.4.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/cloud/google-cloud-storage/1.113.4/google-cloud-storage-1.113.4.jar"}
         },
-        "pypi__coverage_cp311_x86_64-unknown-linux-gnu": {
+        "io_grpc_grpc_context_1_33_1": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-          "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__coverage_cp311_x86_64-unknown-linux-gnu","build_file_content":"--\nfilegroup(\n    name = \"coverage\",\n    srcs = [\"coverage/__main__.py\"],\n    data = glob([\"coverage/*.py\", \"coverage/**/*.py\", \"coverage/*.so\"]),\n    visibility = [\"//visibility:public\"],\n)\n    ","patch_args":["---p1"],"patches":["@@rules_python~0.19.0//python/private:coverage.patch"],"sha256":"--a8fb6cf131ac4070c9c5a3e21de0f7dc5a0fbe8bc77c9456ced896c12fcdad91","type":"--zip","urls":["--https://files.pythonhosted.org/packages/6a/63/8e82513b7e4a1b8d887b4e85c1c2b6c9b754a581b187c0b084f3330ac479/coverage-6.5.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"]}
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~io_grpc_grpc_context_1_33_1","sha256":"--99b8aea2b614fe0e61c3676e681259dc43c2de7f64620998e1a8435eb2976496","urls":["--https://repo1.maven.org/maven2/io/grpc/grpc-context/1.33.1/grpc-context-1.33.1.jar","--https://maven.google.com/io/grpc/grpc-context/1.33.1/grpc-context-1.33.1.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/io/grpc/grpc-context/1.33.1/grpc-context-1.33.1.jar"}
         },
-        "pypi__tomli": {
+        "com_google_api_grpc_proto_google_iam_v1_1_0_3": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-          "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__tomli","url":"--https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl","sha256":"--939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_api_grpc_proto_google_iam_v1_1_0_3","sha256":"--64cee7383a97e846da8d8e160e6c8fe30561e507260552c59e6ccfc81301fdc8","urls":["--https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/1.0.3/proto-google-iam-v1-1.0.3.jar","--https://maven.google.com/com/google/api/grpc/proto-google-iam-v1/1.0.3/proto-google-iam-v1-1.0.3.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/1.0.3/proto-google-iam-v1-1.0.3.jar"}
         },
-        "pypi__coverage_cp39_x86_64-apple-darwin": {
+        "com_google_api_api_common_1_10_1": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-          "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__coverage_cp39_x86_64-apple-darwin","build_file_content":"--\nfilegroup(\n    name = \"coverage\",\n    srcs = [\"coverage/__main__.py\"],\n    data = glob([\"coverage/*.py\", \"coverage/**/*.py\", \"coverage/*.so\"]),\n    visibility = [\"//visibility:public\"],\n)\n    ","patch_args":["---p1"],"patches":["@@rules_python~0.19.0//python/private:coverage.patch"],"sha256":"--633713d70ad6bfc49b34ead4060531658dc6dfc9b3eb7d8a716d5873377ab745","type":"--zip","urls":["--https://files.pythonhosted.org/packages/ea/52/c08080405329326a7ff16c0dfdb4feefaa8edd7446413df67386fe1bbfe0/coverage-6.5.0-cp39-cp39-macosx_10_9_x86_64.whl"]}
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_api_api_common_1_10_1","sha256":"--2a033f24bb620383eda440ad307cb8077cfec1c7eadc684d65216123a1b9613a","urls":["--https://repo1.maven.org/maven2/com/google/api/api-common/1.10.1/api-common-1.10.1.jar","--https://maven.google.com/com/google/api/api-common/1.10.1/api-common-1.10.1.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/api/api-common/1.10.1/api-common-1.10.1.jar"}
         },
+        "com_google_auth_google_auth_library_oauth2_http_0_22_0": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_auth_google_auth_library_oauth2_http_0_22_0","sha256":"--1722d895c42dc42ea1d1f392ddbec1fbb28f7a979022c3a6c29acc39cc777ad1","urls":["--https://repo1.maven.org/maven2/com/google/auth/google-auth-library-oauth2-http/0.22.0/google-auth-library-oauth2-http-0.22.0.jar","--https://maven.google.com/com/google/auth/google-auth-library-oauth2-http/0.22.0/google-auth-library-oauth2-http-0.22.0.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/auth/google-auth-library-oauth2-http/0.22.0/google-auth-library-oauth2-http-0.22.0.jar"}
+        },
+        "com_typesafe_netty_netty_reactive_streams_2_0_5": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_typesafe_netty_netty_reactive_streams_2_0_5","sha256":"--f949849fc8ee75fde468ba3a35df2e04577fa31a2940b83b2a7dc9d14dac13d6","urls":["--https://repo1.maven.org/maven2/com/typesafe/netty/netty-reactive-streams/2.0.5/netty-reactive-streams-2.0.5.jar","--https://maven.google.com/com/typesafe/netty/netty-reactive-streams/2.0.5/netty-reactive-streams-2.0.5.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/typesafe/netty/netty-reactive-streams/2.0.5/netty-reactive-streams-2.0.5.jar"}
+        },
+        "com_typesafe_netty_netty_reactive_streams_http_2_0_5": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_typesafe_netty_netty_reactive_streams_http_2_0_5","sha256":"--b39224751ad936758176e9d994230380ade5e9079e7c8ad778e3995779bcf303","urls":["--https://repo1.maven.org/maven2/com/typesafe/netty/netty-reactive-streams-http/2.0.5/netty-reactive-streams-http-2.0.5.jar","--https://maven.google.com/com/typesafe/netty/netty-reactive-streams-http/2.0.5/netty-reactive-streams-http-2.0.5.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/typesafe/netty/netty-reactive-streams-http/2.0.5/netty-reactive-streams-http-2.0.5.jar"}
+        },
+        "javax_annotation_javax_annotation_api_1_3_2": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~javax_annotation_javax_annotation_api_1_3_2","sha256":"--e04ba5195bcd555dc95650f7cc614d151e4bcd52d29a10b8aa2197f3ab89ab9b","urls":["--https://repo1.maven.org/maven2/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar","--https://maven.google.com/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar"}
+        },
+        "com_google_j2objc_j2objc_annotations_1_3": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_j2objc_j2objc_annotations_1_3","sha256":"--21af30c92267bd6122c0e0b4d20cccb6641a37eaf956c6540ec471d584e64a7b","urls":["--https://repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.3/j2objc-annotations-1.3.jar","--https://maven.google.com/com/google/j2objc/j2objc-annotations/1.3/j2objc-annotations-1.3.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.3/j2objc-annotations-1.3.jar"}
+        },
+        "software_amazon_awssdk_metrics_spi_2_17_183": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~software_amazon_awssdk_metrics_spi_2_17_183","sha256":"--08a11dc8c4ba464beafbcc7ac05b8c724c1ccb93da99482e82a68540ac704e4a","urls":["--https://repo1.maven.org/maven2/software/amazon/awssdk/metrics-spi/2.17.183/metrics-spi-2.17.183.jar","--https://maven.google.com/software/amazon/awssdk/metrics-spi/2.17.183/metrics-spi-2.17.183.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/software/amazon/awssdk/metrics-spi/2.17.183/metrics-spi-2.17.183.jar"}
+        },
+        "org_reactivestreams_reactive_streams_1_0_3": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~org_reactivestreams_reactive_streams_1_0_3","sha256":"--1dee0481072d19c929b623e155e14d2f6085dc011529a0a0dbefc84cf571d865","urls":["--https://repo1.maven.org/maven2/org/reactivestreams/reactive-streams/1.0.3/reactive-streams-1.0.3.jar","--https://maven.google.com/org/reactivestreams/reactive-streams/1.0.3/reactive-streams-1.0.3.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/org/reactivestreams/reactive-streams/1.0.3/reactive-streams-1.0.3.jar"}
+        },
+        "com_google_http_client_google_http_client_jackson2_1_38_0": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_http_client_google_http_client_jackson2_1_38_0","sha256":"--e6504a82425fcc2168a4ca4175138ddcc085168daed8cdedb86d8f6fdc296e1e","urls":["--https://repo1.maven.org/maven2/com/google/http-client/google-http-client-jackson2/1.38.0/google-http-client-jackson2-1.38.0.jar","--https://maven.google.com/com/google/http-client/google-http-client-jackson2/1.38.0/google-http-client-jackson2-1.38.0.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/http-client/google-http-client-jackson2/1.38.0/google-http-client-jackson2-1.38.0.jar"}
+        },
+        "io_netty_netty_transport_4_1_72_Final": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~io_netty_netty_transport_4_1_72_Final","sha256":"--c5fb68e9a65b6e8a516adfcb9fa323479ee7b4d9449d8a529d2ecab3d3711d5a","urls":["--https://repo1.maven.org/maven2/io/netty/netty-transport/4.1.72.Final/netty-transport-4.1.72.Final.jar","--https://maven.google.com/io/netty/netty-transport/4.1.72.Final/netty-transport-4.1.72.Final.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/io/netty/netty-transport/4.1.72.Final/netty-transport-4.1.72.Final.jar"}
+        },
+        "io_netty_netty_codec_http2_4_1_72_Final": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~io_netty_netty_codec_http2_4_1_72_Final","sha256":"--c89a70500f59e8563e720aaa808263a514bd9e2bd91ba84eab8c2ccb45f234b2","urls":["--https://repo1.maven.org/maven2/io/netty/netty-codec-http2/4.1.72.Final/netty-codec-http2-4.1.72.Final.jar","--https://maven.google.com/io/netty/netty-codec-http2/4.1.72.Final/netty-codec-http2-4.1.72.Final.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/io/netty/netty-codec-http2/4.1.72.Final/netty-codec-http2-4.1.72.Final.jar"}
+        },
+        "io_opencensus_opencensus_api_0_24_0": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~io_opencensus_opencensus_api_0_24_0","sha256":"--f561b1cc2673844288e596ddf5bb6596868a8472fd2cb8993953fc5c034b2352","urls":["--https://repo1.maven.org/maven2/io/opencensus/opencensus-api/0.24.0/opencensus-api-0.24.0.jar","--https://maven.google.com/io/opencensus/opencensus-api/0.24.0/opencensus-api-0.24.0.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/io/opencensus/opencensus-api/0.24.0/opencensus-api-0.24.0.jar"}
+        },
+        "rules_jvm_external_deps": {
+          "bzlFile": "@@rules_jvm_external~4.4.2//:coursier.bzl",
+          "ruleClassName": "pinned_coursier_fetch",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~rules_jvm_external_deps","repositories":["--{ \"repo_url\": \"https://repo1.maven.org/maven2\" }"],"artifacts":["--{\"artifact\":\"google-cloud-core\",\"group\":\"com.google.cloud\",\"version\":\"1.93.10\"}","--{\"artifact\":\"google-cloud-storage\",\"group\":\"com.google.cloud\",\"version\":\"1.113.4\"}","--{\"artifact\":\"gson\",\"group\":\"com.google.code.gson\",\"version\":\"2.9.0\"}","--{\"artifact\":\"maven-artifact\",\"group\":\"org.apache.maven\",\"version\":\"3.8.6\"}","--{\"artifact\":\"s3\",\"group\":\"software.amazon.awssdk\",\"version\":\"2.17.183\"}"],"fetch_sources":true,"fetch_javadoc":false,"generate_compat_repositories":false,"maven_install_json":"@@rules_jvm_external~4.4.2//:rules_jvm_external_deps_install.json","override_targets":{},"strict_visibility":false,"strict_visibility_value":["@@//visibility:private"],"jetify":false,"jetify_include_list":["--*"],"additional_netrc_lines":[],"fail_if_repin_required":false,"use_starlark_android_rules":false,"aar_import_bzl_label":"--@build_bazel_rules_android//android:rules.bzl","duplicate_version_warning":"--warn"}
+        },
+        "org_threeten_threetenbp_1_5_0": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~org_threeten_threetenbp_1_5_0","sha256":"--dcf9c0f940739f2a825cd8626ff27113459a2f6eb18797c7152f93fff69c264f","urls":["--https://repo1.maven.org/maven2/org/threeten/threetenbp/1.5.0/threetenbp-1.5.0.jar","--https://maven.google.com/org/threeten/threetenbp/1.5.0/threetenbp-1.5.0.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/org/threeten/threetenbp/1.5.0/threetenbp-1.5.0.jar"}
+        },
+        "software_amazon_awssdk_http_client_spi_2_17_183": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~software_amazon_awssdk_http_client_spi_2_17_183","sha256":"--fe7120f175df9e47ebcc5d946d7f40110faf2ba0a30364f3b935d5b8a5a6c3c6","urls":["--https://repo1.maven.org/maven2/software/amazon/awssdk/http-client-spi/2.17.183/http-client-spi-2.17.183.jar","--https://maven.google.com/software/amazon/awssdk/http-client-spi/2.17.183/http-client-spi-2.17.183.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/software/amazon/awssdk/http-client-spi/2.17.183/http-client-spi-2.17.183.jar"}
+        },
+        "software_amazon_awssdk_third_party_jackson_core_2_17_183": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~software_amazon_awssdk_third_party_jackson_core_2_17_183","sha256":"--1bc27c9960993c20e1ab058012dd1ae04c875eec9f0f08f2b2ca41e578dee9a4","urls":["--https://repo1.maven.org/maven2/software/amazon/awssdk/third-party-jackson-core/2.17.183/third-party-jackson-core-2.17.183.jar","--https://maven.google.com/software/amazon/awssdk/third-party-jackson-core/2.17.183/third-party-jackson-core-2.17.183.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/software/amazon/awssdk/third-party-jackson-core/2.17.183/third-party-jackson-core-2.17.183.jar"}
+        },
+        "software_amazon_eventstream_eventstream_1_0_1": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~software_amazon_eventstream_eventstream_1_0_1","sha256":"--0c37d8e696117f02c302191b8110b0d0eb20fa412fce34c3a269ec73c16ce822","urls":["--https://repo1.maven.org/maven2/software/amazon/eventstream/eventstream/1.0.1/eventstream-1.0.1.jar","--https://maven.google.com/software/amazon/eventstream/eventstream/1.0.1/eventstream-1.0.1.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/software/amazon/eventstream/eventstream/1.0.1/eventstream-1.0.1.jar"}
+        },
+        "com_google_oauth_client_google_oauth_client_1_31_1": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_oauth_client_google_oauth_client_1_31_1","sha256":"--4ed4e2948251dbda66ce251bd7f3b32cd8570055e5cdb165a3c7aea8f43da0ff","urls":["--https://repo1.maven.org/maven2/com/google/oauth-client/google-oauth-client/1.31.1/google-oauth-client-1.31.1.jar","--https://maven.google.com/com/google/oauth-client/google-oauth-client/1.31.1/google-oauth-client-1.31.1.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/oauth-client/google-oauth-client/1.31.1/google-oauth-client-1.31.1.jar"}
+        },
+        "maven": {
+          "bzlFile": "@@rules_jvm_external~4.4.2//:coursier.bzl",
+          "ruleClassName": "coursier_fetch",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~maven","repositories":["--{ \"repo_url\": \"https://repo1.maven.org/maven2\" }"],"artifacts":["--{\"artifact\":\"jsr305\",\"group\":\"com.google.code.findbugs\",\"version\":\"3.0.2\"}","--{\"artifact\":\"gson\",\"group\":\"com.google.code.gson\",\"version\":\"2.8.9\"}","--{\"artifact\":\"error_prone_annotations\",\"group\":\"com.google.errorprone\",\"version\":\"2.3.2\"}","--{\"artifact\":\"j2objc-annotations\",\"group\":\"com.google.j2objc\",\"version\":\"1.3\"}","--{\"artifact\":\"guava\",\"group\":\"com.google.guava\",\"version\":\"31.1-jre\"}","--{\"artifact\":\"guava-testlib\",\"group\":\"com.google.guava\",\"version\":\"31.1-jre\"}","--{\"artifact\":\"truth\",\"group\":\"com.google.truth\",\"version\":\"1.1.2\"}","--{\"artifact\":\"junit\",\"group\":\"junit\",\"version\":\"4.13.2\"}","--{\"artifact\":\"mockito-core\",\"group\":\"org.mockito\",\"version\":\"4.3.1\"}"],"fail_on_missing_checksum":true,"fetch_sources":true,"fetch_javadoc":false,"use_unsafe_shared_cache":false,"excluded_artifacts":[],"generate_compat_repositories":false,"version_conflict_policy":"--default","override_targets":{},"strict_visibility":false,"strict_visibility_value":["@@//visibility:private"],"maven_install_json":null,"resolve_timeout":600,"jetify":false,"jetify_include_list":["--*"],"use_starlark_android_rules":false,"aar_import_bzl_label":"--@build_bazel_rules_android//android:rules.bzl","duplicate_version_warning":"--warn"}
+        },
+        "software_amazon_awssdk_aws_xml_protocol_2_17_183": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~software_amazon_awssdk_aws_xml_protocol_2_17_183","sha256":"--566bba05d49256fa6994efd68fa625ae05a62ea45ee74bb9130d20ea20988363","urls":["--https://repo1.maven.org/maven2/software/amazon/awssdk/aws-xml-protocol/2.17.183/aws-xml-protocol-2.17.183.jar","--https://maven.google.com/software/amazon/awssdk/aws-xml-protocol/2.17.183/aws-xml-protocol-2.17.183.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/software/amazon/awssdk/aws-xml-protocol/2.17.183/aws-xml-protocol-2.17.183.jar"}
+        },
+        "software_amazon_awssdk_annotations_2_17_183": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~software_amazon_awssdk_annotations_2_17_183","sha256":"--8e4d72361ca805a0bd8bbd9017cd7ff77c8d170f2dd469c7d52d5653330bb3fd","urls":["--https://repo1.maven.org/maven2/software/amazon/awssdk/annotations/2.17.183/annotations-2.17.183.jar","--https://maven.google.com/software/amazon/awssdk/annotations/2.17.183/annotations-2.17.183.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/software/amazon/awssdk/annotations/2.17.183/annotations-2.17.183.jar"}
+        },
+        "software_amazon_awssdk_netty_nio_client_2_17_183": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~software_amazon_awssdk_netty_nio_client_2_17_183","sha256":"--a6d356f364c56d7b90006b0b7e503b8630010993a5587ce42e74b10b8dca2238","urls":["--https://repo1.maven.org/maven2/software/amazon/awssdk/netty-nio-client/2.17.183/netty-nio-client-2.17.183.jar","--https://maven.google.com/software/amazon/awssdk/netty-nio-client/2.17.183/netty-nio-client-2.17.183.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/software/amazon/awssdk/netty-nio-client/2.17.183/netty-nio-client-2.17.183.jar"}
+        },
+        "com_google_auto_value_auto_value_annotations_1_7_4": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_auto_value_auto_value_annotations_1_7_4","sha256":"--fedd59b0b4986c342f6ab2d182f2a4ee9fceb2c7e2d5bdc4dc764c92394a23d3","urls":["--https://repo1.maven.org/maven2/com/google/auto/value/auto-value-annotations/1.7.4/auto-value-annotations-1.7.4.jar","--https://maven.google.com/com/google/auto/value/auto-value-annotations/1.7.4/auto-value-annotations-1.7.4.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/auto/value/auto-value-annotations/1.7.4/auto-value-annotations-1.7.4.jar"}
+        },
+        "io_netty_netty_transport_native_unix_common_4_1_72_Final": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~io_netty_netty_transport_native_unix_common_4_1_72_Final","sha256":"--6f8f1cc29b5a234eeee9439a63eb3f03a5994aa540ff555cb0b2c88cefaf6877","urls":["--https://repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/4.1.72.Final/netty-transport-native-unix-common-4.1.72.Final.jar","--https://maven.google.com/io/netty/netty-transport-native-unix-common/4.1.72.Final/netty-transport-native-unix-common-4.1.72.Final.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/4.1.72.Final/netty-transport-native-unix-common-4.1.72.Final.jar"}
+        },
+        "io_opencensus_opencensus_contrib_http_util_0_24_0": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~io_opencensus_opencensus_contrib_http_util_0_24_0","sha256":"--7155273bbb1ed3d477ea33cf19d7bbc0b285ff395f43b29ae576722cf247000f","urls":["--https://repo1.maven.org/maven2/io/opencensus/opencensus-contrib-http-util/0.24.0/opencensus-contrib-http-util-0.24.0.jar","--https://maven.google.com/io/opencensus/opencensus-contrib-http-util/0.24.0/opencensus-contrib-http-util-0.24.0.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/io/opencensus/opencensus-contrib-http-util/0.24.0/opencensus-contrib-http-util-0.24.0.jar"}
+        },
+        "com_fasterxml_jackson_core_jackson_core_2_11_3": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_fasterxml_jackson_core_jackson_core_2_11_3","sha256":"--78cd0a6b936232e06dd3e38da8a0345348a09cd1ff9c4d844c6ee72c75cfc402","urls":["--https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.11.3/jackson-core-2.11.3.jar","--https://maven.google.com/com/fasterxml/jackson/core/jackson-core/2.11.3/jackson-core-2.11.3.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.11.3/jackson-core-2.11.3.jar"}
+        },
+        "com_google_cloud_google_cloud_core_1_93_10": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_cloud_google_cloud_core_1_93_10","sha256":"--832d74eca66f4601e162a8460d6f59f50d1d23f93c18b02654423b6b0d67c6ea","urls":["--https://repo1.maven.org/maven2/com/google/cloud/google-cloud-core/1.93.10/google-cloud-core-1.93.10.jar","--https://maven.google.com/com/google/cloud/google-cloud-core/1.93.10/google-cloud-core-1.93.10.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/cloud/google-cloud-core/1.93.10/google-cloud-core-1.93.10.jar"}
+        },
+        "com_google_auth_google_auth_library_credentials_0_22_0": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_auth_google_auth_library_credentials_0_22_0","sha256":"--42c76031276de5b520909e9faf88c5b3c9a722d69ee9cfdafedb1c52c355dfc5","urls":["--https://repo1.maven.org/maven2/com/google/auth/google-auth-library-credentials/0.22.0/google-auth-library-credentials-0.22.0.jar","--https://maven.google.com/com/google/auth/google-auth-library-credentials/0.22.0/google-auth-library-credentials-0.22.0.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/auth/google-auth-library-credentials/0.22.0/google-auth-library-credentials-0.22.0.jar"}
+        },
+        "com_google_guava_guava_30_0_android": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_guava_guava_30_0_android","sha256":"--3345c82c2cc70a0053e8db9031edc6d71625ef0dea6a2c8f5ebd6cb76d2bf843","urls":["--https://repo1.maven.org/maven2/com/google/guava/guava/30.0-android/guava-30.0-android.jar","--https://maven.google.com/com/google/guava/guava/30.0-android/guava-30.0-android.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/guava/guava/30.0-android/guava-30.0-android.jar"}
+        },
+        "software_amazon_awssdk_profiles_2_17_183": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~software_amazon_awssdk_profiles_2_17_183","sha256":"--78833b32fde3f1c5320373b9ea955c1bbc28f2c904010791c4784e610193ee56","urls":["--https://repo1.maven.org/maven2/software/amazon/awssdk/profiles/2.17.183/profiles-2.17.183.jar","--https://maven.google.com/software/amazon/awssdk/profiles/2.17.183/profiles-2.17.183.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/software/amazon/awssdk/profiles/2.17.183/profiles-2.17.183.jar"}
+        },
+        "org_apache_httpcomponents_httpcore_4_4_13": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~org_apache_httpcomponents_httpcore_4_4_13","sha256":"--e06e89d40943245fcfa39ec537cdbfce3762aecde8f9c597780d2b00c2b43424","urls":["--https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.13/httpcore-4.4.13.jar","--https://maven.google.com/org/apache/httpcomponents/httpcore/4.4.13/httpcore-4.4.13.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.13/httpcore-4.4.13.jar"}
+        },
+        "io_netty_netty_common_4_1_72_Final": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~io_netty_netty_common_4_1_72_Final","sha256":"--8adb4c291260ceb2859a68c49f0adeed36bf49587608e2b81ecff6aaf06025e9","urls":["--https://repo1.maven.org/maven2/io/netty/netty-common/4.1.72.Final/netty-common-4.1.72.Final.jar","--https://maven.google.com/io/netty/netty-common/4.1.72.Final/netty-common-4.1.72.Final.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/io/netty/netty-common/4.1.72.Final/netty-common-4.1.72.Final.jar"}
+        },
+        "io_netty_netty_transport_classes_epoll_4_1_72_Final": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~io_netty_netty_transport_classes_epoll_4_1_72_Final","sha256":"--e1528a9751c1285aa7beaf3a1eb0597151716426ce38598ac9bc0891209b9e68","urls":["--https://repo1.maven.org/maven2/io/netty/netty-transport-classes-epoll/4.1.72.Final/netty-transport-classes-epoll-4.1.72.Final.jar","--https://maven.google.com/io/netty/netty-transport-classes-epoll/4.1.72.Final/netty-transport-classes-epoll-4.1.72.Final.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/io/netty/netty-transport-classes-epoll/4.1.72.Final/netty-transport-classes-epoll-4.1.72.Final.jar"}
+        },
+        "com_google_cloud_google_cloud_core_http_1_93_10": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_cloud_google_cloud_core_http_1_93_10","sha256":"--81ac67c14c7c4244d2b7db2607ad352416aca8d3bb2adf338964e8fea25b1b3c","urls":["--https://repo1.maven.org/maven2/com/google/cloud/google-cloud-core-http/1.93.10/google-cloud-core-http-1.93.10.jar","--https://maven.google.com/com/google/cloud/google-cloud-core-http/1.93.10/google-cloud-core-http-1.93.10.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/cloud/google-cloud-core-http/1.93.10/google-cloud-core-http-1.93.10.jar"}
+        },
+        "software_amazon_awssdk_utils_2_17_183": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~software_amazon_awssdk_utils_2_17_183","sha256":"--7bd849bb5aa71bfdf6b849643736ecab3a7b3f204795804eefe5754104231ec6","urls":["--https://repo1.maven.org/maven2/software/amazon/awssdk/utils/2.17.183/utils-2.17.183.jar","--https://maven.google.com/software/amazon/awssdk/utils/2.17.183/utils-2.17.183.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/software/amazon/awssdk/utils/2.17.183/utils-2.17.183.jar"}
+        },
+        "org_apache_commons_commons_lang3_3_8_1": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~org_apache_commons_commons_lang3_3_8_1","sha256":"--dac807f65b07698ff39b1b07bfef3d87ae3fd46d91bbf8a2bc02b2a831616f68","urls":["--https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar","--https://maven.google.com/org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar"}
+        },
+        "software_amazon_awssdk_aws_core_2_17_183": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~software_amazon_awssdk_aws_core_2_17_183","sha256":"--bccbdbea689a665a702ff19828662d87fb7fe81529df13f02ef1e4c474ea9f93","urls":["--https://repo1.maven.org/maven2/software/amazon/awssdk/aws-core/2.17.183/aws-core-2.17.183.jar","--https://maven.google.com/software/amazon/awssdk/aws-core/2.17.183/aws-core-2.17.183.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/software/amazon/awssdk/aws-core/2.17.183/aws-core-2.17.183.jar"}
+        },
+        "com_google_api_gax_httpjson_0_77_0": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_api_gax_httpjson_0_77_0","sha256":"--fd4dae47fa016d3b26e8d90b67ddc6c23c4c06e8bcdf085c70310ab7ef324bd6","urls":["--https://repo1.maven.org/maven2/com/google/api/gax-httpjson/0.77.0/gax-httpjson-0.77.0.jar","--https://maven.google.com/com/google/api/gax-httpjson/0.77.0/gax-httpjson-0.77.0.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/api/gax-httpjson/0.77.0/gax-httpjson-0.77.0.jar"}
+        },
+        "unpinned_rules_jvm_external_deps": {
+          "bzlFile": "@@rules_jvm_external~4.4.2//:coursier.bzl",
+          "ruleClassName": "coursier_fetch",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~unpinned_rules_jvm_external_deps","repositories":["--{ \"repo_url\": \"https://repo1.maven.org/maven2\" }"],"artifacts":["--{\"artifact\":\"google-cloud-core\",\"group\":\"com.google.cloud\",\"version\":\"1.93.10\"}","--{\"artifact\":\"google-cloud-storage\",\"group\":\"com.google.cloud\",\"version\":\"1.113.4\"}","--{\"artifact\":\"gson\",\"group\":\"com.google.code.gson\",\"version\":\"2.9.0\"}","--{\"artifact\":\"maven-artifact\",\"group\":\"org.apache.maven\",\"version\":\"3.8.6\"}","--{\"artifact\":\"s3\",\"group\":\"software.amazon.awssdk\",\"version\":\"2.17.183\"}"],"fail_on_missing_checksum":true,"fetch_sources":true,"fetch_javadoc":false,"use_unsafe_shared_cache":false,"excluded_artifacts":[],"generate_compat_repositories":false,"version_conflict_policy":"--default","override_targets":{},"strict_visibility":false,"strict_visibility_value":["@@//visibility:private"],"maven_install_json":"@@rules_jvm_external~4.4.2//:rules_jvm_external_deps_install.json","resolve_timeout":600,"jetify":false,"jetify_include_list":["--*"],"use_starlark_android_rules":false,"aar_import_bzl_label":"--@build_bazel_rules_android//android:rules.bzl","duplicate_version_warning":"--warn"}
+        },
+        "software_amazon_awssdk_regions_2_17_183": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~software_amazon_awssdk_regions_2_17_183","sha256":"--d3079395f3ffc07d04ffcce16fca29fb5968197f6e9ea3dbff6be297102b40a5","urls":["--https://repo1.maven.org/maven2/software/amazon/awssdk/regions/2.17.183/regions-2.17.183.jar","--https://maven.google.com/software/amazon/awssdk/regions/2.17.183/regions-2.17.183.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/software/amazon/awssdk/regions/2.17.183/regions-2.17.183.jar"}
+        },
+        "com_google_errorprone_error_prone_annotations_2_4_0": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_errorprone_error_prone_annotations_2_4_0","sha256":"--5f2a0648230a662e8be049df308d583d7369f13af683e44ddf5829b6d741a228","urls":["--https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.4.0/error_prone_annotations-2.4.0.jar","--https://maven.google.com/com/google/errorprone/error_prone_annotations/2.4.0/error_prone_annotations-2.4.0.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.4.0/error_prone_annotations-2.4.0.jar"}
+        },
+        "io_netty_netty_handler_4_1_72_Final": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~io_netty_netty_handler_4_1_72_Final","sha256":"--9cb6012af7e06361d738ac4e3bdc49a158f8cf87d9dee0f2744056b7d99c28d5","urls":["--https://repo1.maven.org/maven2/io/netty/netty-handler/4.1.72.Final/netty-handler-4.1.72.Final.jar","--https://maven.google.com/io/netty/netty-handler/4.1.72.Final/netty-handler-4.1.72.Final.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/io/netty/netty-handler/4.1.72.Final/netty-handler-4.1.72.Final.jar"}
+        },
+        "software_amazon_awssdk_aws_query_protocol_2_17_183": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~software_amazon_awssdk_aws_query_protocol_2_17_183","sha256":"--4dace03c76f80f3dec920cb3dedb2a95984c4366ef4fda728660cb90bed74848","urls":["--https://repo1.maven.org/maven2/software/amazon/awssdk/aws-query-protocol/2.17.183/aws-query-protocol-2.17.183.jar","--https://maven.google.com/software/amazon/awssdk/aws-query-protocol/2.17.183/aws-query-protocol-2.17.183.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/software/amazon/awssdk/aws-query-protocol/2.17.183/aws-query-protocol-2.17.183.jar"}
+        },
+        "io_netty_netty_codec_http_4_1_72_Final": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~io_netty_netty_codec_http_4_1_72_Final","sha256":"--fa6fec88010bfaf6a7415b5364671b6b18ffb6b35a986ab97b423fd8c3a0174b","urls":["--https://repo1.maven.org/maven2/io/netty/netty-codec-http/4.1.72.Final/netty-codec-http-4.1.72.Final.jar","--https://maven.google.com/io/netty/netty-codec-http/4.1.72.Final/netty-codec-http-4.1.72.Final.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/io/netty/netty-codec-http/4.1.72.Final/netty-codec-http-4.1.72.Final.jar"}
+        },
+        "io_netty_netty_resolver_4_1_72_Final": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~io_netty_netty_resolver_4_1_72_Final","sha256":"--6474598aab7cc9d8d6cfa06c05bd1b19adbf7f8451dbdd73070b33a6c60b1b90","urls":["--https://repo1.maven.org/maven2/io/netty/netty-resolver/4.1.72.Final/netty-resolver-4.1.72.Final.jar","--https://maven.google.com/io/netty/netty-resolver/4.1.72.Final/netty-resolver-4.1.72.Final.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/io/netty/netty-resolver/4.1.72.Final/netty-resolver-4.1.72.Final.jar"}
+        },
+        "software_amazon_awssdk_protocol_core_2_17_183": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~software_amazon_awssdk_protocol_core_2_17_183","sha256":"--10e7c4faa1f05e2d73055d0390dbd0bb6450e2e6cb85beda051b1e4693c826ce","urls":["--https://repo1.maven.org/maven2/software/amazon/awssdk/protocol-core/2.17.183/protocol-core-2.17.183.jar","--https://maven.google.com/software/amazon/awssdk/protocol-core/2.17.183/protocol-core-2.17.183.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/software/amazon/awssdk/protocol-core/2.17.183/protocol-core-2.17.183.jar"}
+        },
+        "org_checkerframework_checker_compat_qual_2_5_5": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~org_checkerframework_checker_compat_qual_2_5_5","sha256":"--11d134b245e9cacc474514d2d66b5b8618f8039a1465cdc55bbc0b34e0008b7a","urls":["--https://repo1.maven.org/maven2/org/checkerframework/checker-compat-qual/2.5.5/checker-compat-qual-2.5.5.jar","--https://maven.google.com/org/checkerframework/checker-compat-qual/2.5.5/checker-compat-qual-2.5.5.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/org/checkerframework/checker-compat-qual/2.5.5/checker-compat-qual-2.5.5.jar"}
+        },
+        "com_google_apis_google_api_services_storage_v1_rev20200927_1_30_10": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_apis_google_api_services_storage_v1_rev20200927_1_30_10","sha256":"--52d26a9d105f8d8a0850807285f307a76cea8f3e0cdb2be4d3b15b1adfa77351","urls":["--https://repo1.maven.org/maven2/com/google/apis/google-api-services-storage/v1-rev20200927-1.30.10/google-api-services-storage-v1-rev20200927-1.30.10.jar","--https://maven.google.com/com/google/apis/google-api-services-storage/v1-rev20200927-1.30.10/google-api-services-storage-v1-rev20200927-1.30.10.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/apis/google-api-services-storage/v1-rev20200927-1.30.10/google-api-services-storage-v1-rev20200927-1.30.10.jar"}
+        },
+        "com_google_api_client_google_api_client_1_30_11": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_api_client_google_api_client_1_30_11","sha256":"--ee6f97865cc7de6c7c80955c3f37372cf3887bd75e4fc06f1058a6b4cd9bf4da","urls":["--https://repo1.maven.org/maven2/com/google/api-client/google-api-client/1.30.11/google-api-client-1.30.11.jar","--https://maven.google.com/com/google/api-client/google-api-client/1.30.11/google-api-client-1.30.11.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/api-client/google-api-client/1.30.11/google-api-client-1.30.11.jar"}
+        },
+        "software_amazon_awssdk_s3_2_17_183": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~software_amazon_awssdk_s3_2_17_183","sha256":"--ab073b91107a9e4ed9f030314077d137fe627e055ad895fabb036980a050e360","urls":["--https://repo1.maven.org/maven2/software/amazon/awssdk/s3/2.17.183/s3-2.17.183.jar","--https://maven.google.com/software/amazon/awssdk/s3/2.17.183/s3-2.17.183.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/software/amazon/awssdk/s3/2.17.183/s3-2.17.183.jar"}
+        },
+        "org_apache_maven_maven_artifact_3_8_6": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~org_apache_maven_maven_artifact_3_8_6","sha256":"--de22a4c6f54fe31276a823b1bbd3adfd6823529e732f431b5eff0852c2b9252b","urls":["--https://repo1.maven.org/maven2/org/apache/maven/maven-artifact/3.8.6/maven-artifact-3.8.6.jar","--https://maven.google.com/org/apache/maven/maven-artifact/3.8.6/maven-artifact-3.8.6.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/org/apache/maven/maven-artifact/3.8.6/maven-artifact-3.8.6.jar"}
+        },
+        "org_apache_httpcomponents_httpclient_4_5_13": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~org_apache_httpcomponents_httpclient_4_5_13","sha256":"--6fe9026a566c6a5001608cf3fc32196641f6c1e5e1986d1037ccdbd5f31ef743","urls":["--https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13.jar","--https://maven.google.com/org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13.jar"}
+        },
+        "com_google_guava_listenablefuture_9999_0_empty_to_avoid_conflict_with_guava": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_guava_listenablefuture_9999_0_empty_to_avoid_conflict_with_guava","sha256":"--b372a037d4230aa57fbeffdef30fd6123f9c0c2db85d0aced00c91b974f33f99","urls":["--https://repo1.maven.org/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar","--https://maven.google.com/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"}
+        },
+        "com_google_http_client_google_http_client_1_38_0": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_http_client_google_http_client_1_38_0","sha256":"--411f4a42519b6b78bdc0fcfdf74c9edcef0ee97afa4a667abe04045a508d6302","urls":["--https://repo1.maven.org/maven2/com/google/http-client/google-http-client/1.38.0/google-http-client-1.38.0.jar","--https://maven.google.com/com/google/http-client/google-http-client/1.38.0/google-http-client-1.38.0.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/http-client/google-http-client/1.38.0/google-http-client-1.38.0.jar"}
+        },
+        "software_amazon_awssdk_apache_client_2_17_183": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~software_amazon_awssdk_apache_client_2_17_183","sha256":"--78ceae502fce6a97bbe5ff8f6a010a52ab7ea3ae66cb1a4122e18185fce45022","urls":["--https://repo1.maven.org/maven2/software/amazon/awssdk/apache-client/2.17.183/apache-client-2.17.183.jar","--https://maven.google.com/software/amazon/awssdk/apache-client/2.17.183/apache-client-2.17.183.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/software/amazon/awssdk/apache-client/2.17.183/apache-client-2.17.183.jar"}
+        },
+        "software_amazon_awssdk_arns_2_17_183": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~software_amazon_awssdk_arns_2_17_183","sha256":"--659a185e191d66c71de81209490e66abeaccae208ea7b2831a738670823447aa","urls":["--https://repo1.maven.org/maven2/software/amazon/awssdk/arns/2.17.183/arns-2.17.183.jar","--https://maven.google.com/software/amazon/awssdk/arns/2.17.183/arns-2.17.183.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/software/amazon/awssdk/arns/2.17.183/arns-2.17.183.jar"}
+        },
+        "com_google_code_gson_gson_2_9_0": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_code_gson_gson_2_9_0","sha256":"--c96d60551331a196dac54b745aa642cd078ef89b6f267146b705f2c2cbef052d","urls":["--https://repo1.maven.org/maven2/com/google/code/gson/gson/2.9.0/gson-2.9.0.jar","--https://maven.google.com/com/google/code/gson/gson/2.9.0/gson-2.9.0.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/code/gson/gson/2.9.0/gson-2.9.0.jar"}
+        },
+        "io_netty_netty_buffer_4_1_72_Final": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~io_netty_netty_buffer_4_1_72_Final","sha256":"--568ff7cd9d8e2284ec980730c88924f686642929f8f219a74518b4e64755f3a1","urls":["--https://repo1.maven.org/maven2/io/netty/netty-buffer/4.1.72.Final/netty-buffer-4.1.72.Final.jar","--https://maven.google.com/io/netty/netty-buffer/4.1.72.Final/netty-buffer-4.1.72.Final.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/io/netty/netty-buffer/4.1.72.Final/netty-buffer-4.1.72.Final.jar"}
+        },
+        "com_google_code_findbugs_jsr305_3_0_2": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_code_findbugs_jsr305_3_0_2","sha256":"--766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7","urls":["--https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar","--https://maven.google.com/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"}
+        },
+        "commons_codec_commons_codec_1_11": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~commons_codec_commons_codec_1_11","sha256":"--e599d5318e97aa48f42136a2927e6dfa4e8881dff0e6c8e3109ddbbff51d7b7d","urls":["--https://repo1.maven.org/maven2/commons-codec/commons-codec/1.11/commons-codec-1.11.jar","--https://maven.google.com/commons-codec/commons-codec/1.11/commons-codec-1.11.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/commons-codec/commons-codec/1.11/commons-codec-1.11.jar"}
+        },
+        "software_amazon_awssdk_auth_2_17_183": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~software_amazon_awssdk_auth_2_17_183","sha256":"--8820c6636e5c14efc29399fb5565ce50212b0c1f4ed720a025a2c402d54e0978","urls":["--https://repo1.maven.org/maven2/software/amazon/awssdk/auth/2.17.183/auth-2.17.183.jar","--https://maven.google.com/software/amazon/awssdk/auth/2.17.183/auth-2.17.183.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/software/amazon/awssdk/auth/2.17.183/auth-2.17.183.jar"}
+        },
+        "software_amazon_awssdk_json_utils_2_17_183": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~software_amazon_awssdk_json_utils_2_17_183","sha256":"--51ab7f550adc06afcb49f5270cdf690f1bfaaee243abaa5d978095e2a1e4e1a5","urls":["--https://repo1.maven.org/maven2/software/amazon/awssdk/json-utils/2.17.183/json-utils-2.17.183.jar","--https://maven.google.com/software/amazon/awssdk/json-utils/2.17.183/json-utils-2.17.183.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/software/amazon/awssdk/json-utils/2.17.183/json-utils-2.17.183.jar"}
+        },
+        "org_codehaus_plexus_plexus_utils_3_3_1": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~org_codehaus_plexus_plexus_utils_3_3_1","sha256":"--4b570fcdbe5a894f249d2eb9b929358a9c88c3e548d227a80010461930222f2a","urls":["--https://repo1.maven.org/maven2/org/codehaus/plexus/plexus-utils/3.3.1/plexus-utils-3.3.1.jar","--https://maven.google.com/org/codehaus/plexus/plexus-utils/3.3.1/plexus-utils-3.3.1.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/org/codehaus/plexus/plexus-utils/3.3.1/plexus-utils-3.3.1.jar"}
+        },
+        "com_google_protobuf_protobuf_java_util_3_13_0": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_protobuf_protobuf_java_util_3_13_0","sha256":"--d9de66b8c9445905dfa7064f6d5213d47ce88a20d34e21d83c4a94a229e14e62","urls":["--https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.13.0/protobuf-java-util-3.13.0.jar","--https://maven.google.com/com/google/protobuf/protobuf-java-util/3.13.0/protobuf-java-util-3.13.0.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.13.0/protobuf-java-util-3.13.0.jar"}
+        },
+        "io_netty_netty_codec_4_1_72_Final": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~io_netty_netty_codec_4_1_72_Final","sha256":"--5d8591ca271a1e9c224e8de3873aa9936acb581ee0db514e7dc18523df36d16c","urls":["--https://repo1.maven.org/maven2/io/netty/netty-codec/4.1.72.Final/netty-codec-4.1.72.Final.jar","--https://maven.google.com/io/netty/netty-codec/4.1.72.Final/netty-codec-4.1.72.Final.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/io/netty/netty-codec/4.1.72.Final/netty-codec-4.1.72.Final.jar"}
+        },
+        "com_google_protobuf_protobuf_java_3_13_0": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~com_google_protobuf_protobuf_java_3_13_0","sha256":"--97d5b2758408690c0dc276238707492a0b6a4d71206311b6c442cdc26c5973ff","urls":["--https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.13.0/protobuf-java-3.13.0.jar","--https://maven.google.com/com/google/protobuf/protobuf-java/3.13.0/protobuf-java-3.13.0.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.13.0/protobuf-java-3.13.0.jar"}
+        },
+        "io_netty_netty_tcnative_classes_2_0_46_Final": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~io_netty_netty_tcnative_classes_2_0_46_Final","sha256":"--d3ec888dcc4ac7915bf88b417c5e04fd354f4311032a748a6882df09347eed9a","urls":["--https://repo1.maven.org/maven2/io/netty/netty-tcnative-classes/2.0.46.Final/netty-tcnative-classes-2.0.46.Final.jar","--https://maven.google.com/io/netty/netty-tcnative-classes/2.0.46.Final/netty-tcnative-classes-2.0.46.Final.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/io/netty/netty-tcnative-classes/2.0.46.Final/netty-tcnative-classes-2.0.46.Final.jar"}
+        },
+        "software_amazon_awssdk_sdk_core_2_17_183": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_file",
+          "attributes": {"name":"--rules_jvm_external~4.4.2~maven~software_amazon_awssdk_sdk_core_2_17_183","sha256":"--677e9cc90fdd82c1f40f97b99cb115b13ad6c3f58beeeab1c061af6954d64c77","urls":["--https://repo1.maven.org/maven2/software/amazon/awssdk/sdk-core/2.17.183/sdk-core-2.17.183.jar","--https://maven.google.com/software/amazon/awssdk/sdk-core/2.17.183/sdk-core-2.17.183.jar"],"downloaded_file_path":"--v1/https/repo1.maven.org/maven2/software/amazon/awssdk/sdk-core/2.17.183/sdk-core-2.17.183.jar"}
+        }
+      }
+    },
+    "@rules_python~0.24.0//python/extensions:python.bzl%python": {
+      "bzlTransitiveDigest": "9sVLcm29C6eY7TfBei6hgV2sqrC2SqgOPeB3aEjaPfU=",
+      "accumulatedFileDigests": {},
+      "envVariables": {},
+      "generatedRepoSpecs": {
+        "python_3_11_aarch64-unknown-linux-gnu": {
+          "bzlFile": "@@rules_python~0.24.0//python:repositories.bzl",
+          "ruleClassName": "python_repository",
+          "attributes": {"name":"--rules_python~0.24.0~python~python_3_11_aarch64-unknown-linux-gnu","sha256":"--debf15783bdcb5530504f533d33fda75a7b905cec5361ae8f33da5ba6599f8b4","patches":[],"platform":"--aarch64-unknown-linux-gnu","python_version":"--3.11.1","release_filename":"--20230116/cpython-3.11.1+20230116-aarch64-unknown-linux-gnu-install_only.tar.gz","urls":["--https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1+20230116-aarch64-unknown-linux-gnu-install_only.tar.gz"],"distutils":null,"distutils_content":"--","strip_prefix":"--python","coverage_tool":"--","ignore_root_user_error":false}
+        },
+        "python_3_9": {
+          "bzlFile": "@@rules_python~0.24.0//python/private:toolchains_repo.bzl",
+          "ruleClassName": "toolchain_aliases",
+          "attributes": {"name":"--rules_python~0.24.0~python~python_3_9","python_version":"--3.9.16","user_repository_name":"--python_3_9"}
+        },
+        "python_3_11_aarch64-apple-darwin": {
+          "bzlFile": "@@rules_python~0.24.0//python:repositories.bzl",
+          "ruleClassName": "python_repository",
+          "attributes": {"name":"--rules_python~0.24.0~python~python_3_11_aarch64-apple-darwin","sha256":"--4918cdf1cab742a90f85318f88b8122aeaa2d04705803c7b6e78e81a3dd40f80","patches":[],"platform":"--aarch64-apple-darwin","python_version":"--3.11.1","release_filename":"--20230116/cpython-3.11.1+20230116-aarch64-apple-darwin-install_only.tar.gz","urls":["--https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1+20230116-aarch64-apple-darwin-install_only.tar.gz"],"distutils":null,"distutils_content":"--","strip_prefix":"--python","coverage_tool":"--","ignore_root_user_error":false}
+        },
+        "pythons_hub": {
+          "bzlFile": "@@rules_python~0.24.0//python/extensions/private:pythons_hub.bzl",
+          "ruleClassName": "hub_repo",
+          "attributes": {"name":"--rules_python~0.24.0~python~pythons_hub","default_python_version":"--3.9","toolchain_prefixes":["--_0000_python_3_11_","--_0001_python_3_9_"],"toolchain_python_versions":["--3.11","--3.9"],"toolchain_set_python_version_constraints":["--True","--False"],"toolchain_user_repository_names":["--python_3_11","--python_3_9"]}
+        },
+        "python_3_11_x86_64-pc-windows-msvc": {
+          "bzlFile": "@@rules_python~0.24.0//python:repositories.bzl",
+          "ruleClassName": "python_repository",
+          "attributes": {"name":"--rules_python~0.24.0~python~python_3_11_x86_64-pc-windows-msvc","sha256":"--edc08979cb0666a597466176511529c049a6f0bba8adf70df441708f766de5bf","patches":[],"platform":"--x86_64-pc-windows-msvc","python_version":"--3.11.1","release_filename":"--20230116/cpython-3.11.1+20230116-x86_64-pc-windows-msvc-shared-install_only.tar.gz","urls":["--https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1+20230116-x86_64-pc-windows-msvc-shared-install_only.tar.gz"],"distutils":null,"distutils_content":"--","strip_prefix":"--python","coverage_tool":"--","ignore_root_user_error":false}
+        },
+        "python_3_9_aarch64-apple-darwin": {
+          "bzlFile": "@@rules_python~0.24.0//python:repositories.bzl",
+          "ruleClassName": "python_repository",
+          "attributes": {"name":"--rules_python~0.24.0~python~python_3_9_aarch64-apple-darwin","sha256":"--c1de1d854717a6245f45262ef1bb17b09e2c587590e7e3f406593c143ff875bd","patches":[],"platform":"--aarch64-apple-darwin","python_version":"--3.9.16","release_filename":"--20230507/cpython-3.9.16+20230507-aarch64-apple-darwin-install_only.tar.gz","urls":["--https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16+20230507-aarch64-apple-darwin-install_only.tar.gz"],"distutils":null,"distutils_content":"--","strip_prefix":"--python","coverage_tool":"--","ignore_root_user_error":false}
+        },
+        "python_3_9_x86_64-pc-windows-msvc": {
+          "bzlFile": "@@rules_python~0.24.0//python:repositories.bzl",
+          "ruleClassName": "python_repository",
+          "attributes": {"name":"--rules_python~0.24.0~python~python_3_9_x86_64-pc-windows-msvc","sha256":"--cdabb47204e96ce7ea31fbd0b5ed586114dd7d8f8eddf60a509a7f70b48a1c5e","patches":[],"platform":"--x86_64-pc-windows-msvc","python_version":"--3.9.16","release_filename":"--20230507/cpython-3.9.16+20230507-x86_64-pc-windows-msvc-shared-install_only.tar.gz","urls":["--https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16+20230507-x86_64-pc-windows-msvc-shared-install_only.tar.gz"],"distutils":null,"distutils_content":"--","strip_prefix":"--python","coverage_tool":"--","ignore_root_user_error":false}
+        },
+        "python_3_9_ppc64le-unknown-linux-gnu": {
+          "bzlFile": "@@rules_python~0.24.0//python:repositories.bzl",
+          "ruleClassName": "python_repository",
+          "attributes": {"name":"--rules_python~0.24.0~python~python_3_9_ppc64le-unknown-linux-gnu","sha256":"--ff3ac35c58f67839aff9b5185a976abd3d1abbe61af02089f7105e876c1fe284","patches":[],"platform":"--ppc64le-unknown-linux-gnu","python_version":"--3.9.16","release_filename":"--20230507/cpython-3.9.16+20230507-ppc64le-unknown-linux-gnu-install_only.tar.gz","urls":["--https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16+20230507-ppc64le-unknown-linux-gnu-install_only.tar.gz"],"distutils":null,"distutils_content":"--","strip_prefix":"--python","coverage_tool":"--","ignore_root_user_error":false}
+        },
+        "python_3_9_aarch64-unknown-linux-gnu": {
+          "bzlFile": "@@rules_python~0.24.0//python:repositories.bzl",
+          "ruleClassName": "python_repository",
+          "attributes": {"name":"--rules_python~0.24.0~python~python_3_9_aarch64-unknown-linux-gnu","sha256":"--f629b75ebfcafe9ceee2e796b7e4df5cf8dbd14f3c021afca078d159ab797acf","patches":[],"platform":"--aarch64-unknown-linux-gnu","python_version":"--3.9.16","release_filename":"--20230507/cpython-3.9.16+20230507-aarch64-unknown-linux-gnu-install_only.tar.gz","urls":["--https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16+20230507-aarch64-unknown-linux-gnu-install_only.tar.gz"],"distutils":null,"distutils_content":"--","strip_prefix":"--python","coverage_tool":"--","ignore_root_user_error":false}
+        },
+        "python_3_11": {
+          "bzlFile": "@@rules_python~0.24.0//python/private:toolchains_repo.bzl",
+          "ruleClassName": "toolchain_aliases",
+          "attributes": {"name":"--rules_python~0.24.0~python~python_3_11","python_version":"--3.11.1","user_repository_name":"--python_3_11"}
+        },
+        "python_3_11_x86_64-apple-darwin": {
+          "bzlFile": "@@rules_python~0.24.0//python:repositories.bzl",
+          "ruleClassName": "python_repository",
+          "attributes": {"name":"--rules_python~0.24.0~python~python_3_11_x86_64-apple-darwin","sha256":"--20a4203d069dc9b710f70b09e7da2ce6f473d6b1110f9535fb6f4c469ed54733","patches":[],"platform":"--x86_64-apple-darwin","python_version":"--3.11.1","release_filename":"--20230116/cpython-3.11.1+20230116-x86_64-apple-darwin-install_only.tar.gz","urls":["--https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1+20230116-x86_64-apple-darwin-install_only.tar.gz"],"distutils":null,"distutils_content":"--","strip_prefix":"--python","coverage_tool":"--","ignore_root_user_error":false}
+        },
+        "python_versions": {
+          "bzlFile": "@@rules_python~0.24.0//python/private:toolchains_repo.bzl",
+          "ruleClassName": "multi_toolchain_aliases",
+          "attributes": {"name":"--rules_python~0.24.0~python~python_versions","python_versions":{"--3.9":"--python_3_9","--3.11":"--python_3_11"}}
+        },
+        "python_3_9_x86_64-apple-darwin": {
+          "bzlFile": "@@rules_python~0.24.0//python:repositories.bzl",
+          "ruleClassName": "python_repository",
+          "attributes": {"name":"--rules_python~0.24.0~python~python_3_9_x86_64-apple-darwin","sha256":"--3abc4d5fbbc80f5f848f280927ac5d13de8dc03aabb6ae65d8247cbb68e6f6bf","patches":[],"platform":"--x86_64-apple-darwin","python_version":"--3.9.16","release_filename":"--20230507/cpython-3.9.16+20230507-x86_64-apple-darwin-install_only.tar.gz","urls":["--https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16+20230507-x86_64-apple-darwin-install_only.tar.gz"],"distutils":null,"distutils_content":"--","strip_prefix":"--python","coverage_tool":"--","ignore_root_user_error":false}
+        },
+        "python_3_9_x86_64-unknown-linux-gnu": {
+          "bzlFile": "@@rules_python~0.24.0//python:repositories.bzl",
+          "ruleClassName": "python_repository",
+          "attributes": {"name":"--rules_python~0.24.0~python~python_3_9_x86_64-unknown-linux-gnu","sha256":"--2b6e146234a4ef2a8946081fc3fbfffe0765b80b690425a49ebe40b47c33445b","patches":[],"platform":"--x86_64-unknown-linux-gnu","python_version":"--3.9.16","release_filename":"--20230507/cpython-3.9.16+20230507-x86_64-unknown-linux-gnu-install_only.tar.gz","urls":["--https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16+20230507-x86_64-unknown-linux-gnu-install_only.tar.gz"],"distutils":null,"distutils_content":"--","strip_prefix":"--python","coverage_tool":"--","ignore_root_user_error":false}
+        },
+        "python_3_11_x86_64-unknown-linux-gnu": {
+          "bzlFile": "@@rules_python~0.24.0//python:repositories.bzl",
+          "ruleClassName": "python_repository",
+          "attributes": {"name":"--rules_python~0.24.0~python~python_3_11_x86_64-unknown-linux-gnu","sha256":"--02a551fefab3750effd0e156c25446547c238688a32fabde2995c941c03a6423","patches":[],"platform":"--x86_64-unknown-linux-gnu","python_version":"--3.11.1","release_filename":"--20230116/cpython-3.11.1+20230116-x86_64-unknown-linux-gnu-install_only.tar.gz","urls":["--https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1+20230116-x86_64-unknown-linux-gnu-install_only.tar.gz"],"distutils":null,"distutils_content":"--","strip_prefix":"--python","coverage_tool":"--","ignore_root_user_error":false}
+        }
+      }
+    },
+    "@rules_python~0.24.0//python/extensions:pip.bzl%pip": {
+      "bzlTransitiveDigest": "uuhr/ij69KtQ4mZm4UIhaa8BGn3EkH/dfqngcS18ZiM=",
+      "accumulatedFileDigests": {
+        "@@//:requirements.txt": "0199ba5bd115b3258f75d5aaf9d04cc13010e4c1026c77ab4d7c6ad1eadfac1d"
+      },
+      "envVariables": {},
+      "generatedRepoSpecs": {
+        "pip_39_tomli": {
+          "bzlFile": "@@rules_python~0.24.0//python/pip_install:pip_repository.bzl",
+          "ruleClassName": "whl_library",
+          "attributes": {"name":"--rules_python~0.24.0~pip~pip_39_tomli","requirement":"--tomli==2.0.1     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f","repo":"--pip_39","repo_prefix":"--pip_39_","annotation":null,"python_interpreter":"--","python_interpreter_target":"@@rules_python~0.24.0~python~python_3_9_x86_64-apple-darwin//:bin/python3","quiet":true,"timeout":600,"isolated":true,"extra_pip_args":[],"download_only":false,"pip_data_exclude":[],"enable_implicit_namespace_pkgs":false,"environment":{}}
+        },
+        "pip_iniconfig": {
+          "bzlFile": "@@rules_python~0.24.0//python:pip.bzl",
+          "ruleClassName": "whl_library_alias",
+          "attributes": {"name":"--rules_python~0.24.0~pip~pip_iniconfig","wheel_name":"--iniconfig","default_version":"--3.9","version_map":{"--3.9":"--pip_39_"}}
+        },
+        "pip_39_packaging": {
+          "bzlFile": "@@rules_python~0.24.0//python/pip_install:pip_repository.bzl",
+          "ruleClassName": "whl_library",
+          "attributes": {"name":"--rules_python~0.24.0~pip~pip_39_packaging","requirement":"--packaging==23.1     --hash=sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61     --hash=sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f","repo":"--pip_39","repo_prefix":"--pip_39_","annotation":null,"python_interpreter":"--","python_interpreter_target":"@@rules_python~0.24.0~python~python_3_9_x86_64-apple-darwin//:bin/python3","quiet":true,"timeout":600,"isolated":true,"extra_pip_args":[],"download_only":false,"pip_data_exclude":[],"enable_implicit_namespace_pkgs":false,"environment":{}}
+        },
+        "pip_exceptiongroup": {
+          "bzlFile": "@@rules_python~0.24.0//python:pip.bzl",
+          "ruleClassName": "whl_library_alias",
+          "attributes": {"name":"--rules_python~0.24.0~pip~pip_exceptiongroup","wheel_name":"--exceptiongroup","default_version":"--3.9","version_map":{"--3.9":"--pip_39_"}}
+        },
+        "pip_pluggy": {
+          "bzlFile": "@@rules_python~0.24.0//python:pip.bzl",
+          "ruleClassName": "whl_library_alias",
+          "attributes": {"name":"--rules_python~0.24.0~pip~pip_pluggy","wheel_name":"--pluggy","default_version":"--3.9","version_map":{"--3.9":"--pip_39_"}}
+        },
+        "pip_pytest": {
+          "bzlFile": "@@rules_python~0.24.0//python:pip.bzl",
+          "ruleClassName": "whl_library_alias",
+          "attributes": {"name":"--rules_python~0.24.0~pip~pip_pytest","wheel_name":"--pytest","default_version":"--3.9","version_map":{"--3.9":"--pip_39_"}}
+        },
+        "pip_39_pluggy": {
+          "bzlFile": "@@rules_python~0.24.0//python/pip_install:pip_repository.bzl",
+          "ruleClassName": "whl_library",
+          "attributes": {"name":"--rules_python~0.24.0~pip~pip_39_pluggy","requirement":"--pluggy==1.2.0     --hash=sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849     --hash=sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3","repo":"--pip_39","repo_prefix":"--pip_39_","annotation":null,"python_interpreter":"--","python_interpreter_target":"@@rules_python~0.24.0~python~python_3_9_x86_64-apple-darwin//:bin/python3","quiet":true,"timeout":600,"isolated":true,"extra_pip_args":[],"download_only":false,"pip_data_exclude":[],"enable_implicit_namespace_pkgs":false,"environment":{}}
+        },
+        "pip_packaging": {
+          "bzlFile": "@@rules_python~0.24.0//python:pip.bzl",
+          "ruleClassName": "whl_library_alias",
+          "attributes": {"name":"--rules_python~0.24.0~pip~pip_packaging","wheel_name":"--packaging","default_version":"--3.9","version_map":{"--3.9":"--pip_39_"}}
+        },
+        "pip_39": {
+          "bzlFile": "@@rules_python~0.24.0//python/pip_install:pip_repository.bzl",
+          "ruleClassName": "pip_repository_bzlmod",
+          "attributes": {"name":"--rules_python~0.24.0~pip~pip_39","repo_name":"--pip_39","requirements_lock":"@@//:requirements.txt"}
+        },
+        "pip": {
+          "bzlFile": "@@rules_python~0.24.0//python/pip_install:pip_repository.bzl",
+          "ruleClassName": "pip_hub_repository_bzlmod",
+          "attributes": {"name":"--rules_python~0.24.0~pip~pip","repo_name":"--pip","whl_library_alias_names":["--exceptiongroup","--iniconfig","--packaging","--pluggy","--pytest","--tomli"]}
+        },
+        "pip_39_exceptiongroup": {
+          "bzlFile": "@@rules_python~0.24.0//python/pip_install:pip_repository.bzl",
+          "ruleClassName": "whl_library",
+          "attributes": {"name":"--rules_python~0.24.0~pip~pip_39_exceptiongroup","requirement":"--exceptiongroup==1.1.2     --hash=sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5     --hash=sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f","repo":"--pip_39","repo_prefix":"--pip_39_","annotation":null,"python_interpreter":"--","python_interpreter_target":"@@rules_python~0.24.0~python~python_3_9_x86_64-apple-darwin//:bin/python3","quiet":true,"timeout":600,"isolated":true,"extra_pip_args":[],"download_only":false,"pip_data_exclude":[],"enable_implicit_namespace_pkgs":false,"environment":{}}
+        },
+        "pip_39_iniconfig": {
+          "bzlFile": "@@rules_python~0.24.0//python/pip_install:pip_repository.bzl",
+          "ruleClassName": "whl_library",
+          "attributes": {"name":"--rules_python~0.24.0~pip~pip_39_iniconfig","requirement":"--iniconfig==2.0.0     --hash=sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3     --hash=sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374","repo":"--pip_39","repo_prefix":"--pip_39_","annotation":null,"python_interpreter":"--","python_interpreter_target":"@@rules_python~0.24.0~python~python_3_9_x86_64-apple-darwin//:bin/python3","quiet":true,"timeout":600,"isolated":true,"extra_pip_args":[],"download_only":false,"pip_data_exclude":[],"enable_implicit_namespace_pkgs":false,"environment":{}}
+        },
+        "pip_39_pytest": {
+          "bzlFile": "@@rules_python~0.24.0//python/pip_install:pip_repository.bzl",
+          "ruleClassName": "whl_library",
+          "attributes": {"name":"--rules_python~0.24.0~pip~pip_39_pytest","requirement":"--pytest==7.3.2     --hash=sha256:cdcbd012c9312258922f8cd3f1b62a6580fdced17db6014896053d47cddf9295     --hash=sha256:ee990a3cc55ba808b80795a79944756f315c67c12b56abd3ac993a7b8c17030b","repo":"--pip_39","repo_prefix":"--pip_39_","annotation":null,"python_interpreter":"--","python_interpreter_target":"@@rules_python~0.24.0~python~python_3_9_x86_64-apple-darwin//:bin/python3","quiet":true,"timeout":600,"isolated":true,"extra_pip_args":[],"download_only":false,"pip_data_exclude":[],"enable_implicit_namespace_pkgs":false,"environment":{}}
+        },
+        "pip_tomli": {
+          "bzlFile": "@@rules_python~0.24.0//python:pip.bzl",
+          "ruleClassName": "whl_library_alias",
+          "attributes": {"name":"--rules_python~0.24.0~pip~pip_tomli","wheel_name":"--tomli","default_version":"--3.9","version_map":{"--3.9":"--pip_39_"}}
+        }
+      }
+    },
+    "@rules_python~0.24.0//python/extensions/private:internal_deps.bzl%internal_deps": {
+      "bzlTransitiveDigest": "d0GVFr68Y+3LHnWTnpXEqHou3XKRA+BYjeOeYY1wb2k=",
+      "accumulatedFileDigests": {},
+      "envVariables": {},
+      "generatedRepoSpecs": {
         "pypi__wheel": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
           "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__wheel","url":"--https://files.pythonhosted.org/packages/bd/7c/d38a0b30ce22fc26ed7dbc087c6d00851fb3395e9d0dac40bec1f905030c/wheel-0.38.4-py3-none-any.whl","sha256":"--b60533f3f5d530e971d6737ca6d58681ee434818fab630c83a734bb10c083ce8","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
-        },
-        "pypi__coverage_cp311_aarch64-unknown-linux-gnu": {
-          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-          "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__coverage_cp311_aarch64-unknown-linux-gnu","build_file_content":"--\nfilegroup(\n    name = \"coverage\",\n    srcs = [\"coverage/__main__.py\"],\n    data = glob([\"coverage/*.py\", \"coverage/**/*.py\", \"coverage/*.so\"]),\n    visibility = [\"//visibility:public\"],\n)\n    ","patch_args":["---p1"],"patches":["@@rules_python~0.19.0//python/private:coverage.patch"],"sha256":"--c4ed2820d919351f4167e52425e096af41bfabacb1857186c1ea32ff9983ed75","type":"--zip","urls":["--https://files.pythonhosted.org/packages/36/f3/5cbd79cf4cd059c80b59104aca33b8d05af4ad5bf5b1547645ecee716378/coverage-6.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"]}
+          "attributes": {"name":"--rules_python~0.24.0~internal_deps~pypi__wheel","url":"--https://files.pythonhosted.org/packages/bd/7c/d38a0b30ce22fc26ed7dbc087c6d00851fb3395e9d0dac40bec1f905030c/wheel-0.38.4-py3-none-any.whl","sha256":"--b60533f3f5d530e971d6737ca6d58681ee434818fab630c83a734bb10c083ce8","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
         },
         "pypi__click": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
           "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__click","url":"--https://files.pythonhosted.org/packages/76/0a/b6c5f311e32aeb3b406e03c079ade51e905ea630fc19d1262a46249c1c86/click-8.0.1-py3-none-any.whl","sha256":"--fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
-        },
-        "pypi__coverage_cp39_x86_64-unknown-linux-gnu": {
-          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-          "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__coverage_cp39_x86_64-unknown-linux-gnu","build_file_content":"--\nfilegroup(\n    name = \"coverage\",\n    srcs = [\"coverage/__main__.py\"],\n    data = glob([\"coverage/*.py\", \"coverage/**/*.py\", \"coverage/*.so\"]),\n    visibility = [\"//visibility:public\"],\n)\n    ","patch_args":["---p1"],"patches":["@@rules_python~0.19.0//python/private:coverage.patch"],"sha256":"--8f830ed581b45b82451a40faabb89c84e1a998124ee4212d440e9c6cf70083e5","type":"--zip","urls":["--https://files.pythonhosted.org/packages/6b/f2/919f0fdc93d3991ca074894402074d847be8ac1e1d78e7e9e1c371b69a6f/coverage-6.5.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"]}
+          "attributes": {"name":"--rules_python~0.24.0~internal_deps~pypi__click","url":"--https://files.pythonhosted.org/packages/76/0a/b6c5f311e32aeb3b406e03c079ade51e905ea630fc19d1262a46249c1c86/click-8.0.1-py3-none-any.whl","sha256":"--fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
         },
         "pypi__importlib_metadata": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
           "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__importlib_metadata","url":"--https://files.pythonhosted.org/packages/d7/31/74dcb59a601b95fce3b0334e8fc9db758f78e43075f22aeb3677dfb19f4c/importlib_metadata-1.4.0-py2.py3-none-any.whl","sha256":"--bdd9b7c397c273bcc9a11d6629a38487cd07154fa255a467bf704cd2c258e359","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
+          "attributes": {"name":"--rules_python~0.24.0~internal_deps~pypi__importlib_metadata","url":"--https://files.pythonhosted.org/packages/d7/31/74dcb59a601b95fce3b0334e8fc9db758f78e43075f22aeb3677dfb19f4c/importlib_metadata-1.4.0-py2.py3-none-any.whl","sha256":"--bdd9b7c397c273bcc9a11d6629a38487cd07154fa255a467bf704cd2c258e359","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
         },
         "pypi__pep517": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
           "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__pep517","url":"--https://files.pythonhosted.org/packages/ee/2f/ef63e64e9429111e73d3d6cbee80591672d16f2725e648ebc52096f3d323/pep517-0.13.0-py3-none-any.whl","sha256":"--4ba4446d80aed5b5eac6509ade100bff3e7943a8489de249654a5ae9b33ee35b","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
-        },
-        "pypi__coverage_cp38_x86_64-unknown-linux-gnu": {
-          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-          "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__coverage_cp38_x86_64-unknown-linux-gnu","build_file_content":"--\nfilegroup(\n    name = \"coverage\",\n    srcs = [\"coverage/__main__.py\"],\n    data = glob([\"coverage/*.py\", \"coverage/**/*.py\", \"coverage/*.so\"]),\n    visibility = [\"//visibility:public\"],\n)\n    ","patch_args":["---p1"],"patches":["@@rules_python~0.19.0//python/private:coverage.patch"],"sha256":"--6b07130585d54fe8dff3d97b93b0e20290de974dc8177c320aeaf23459219c0b","type":"--zip","urls":["--https://files.pythonhosted.org/packages/bd/a0/e263b115808226fdb2658f1887808c06ac3f1b579ef5dda02309e0d54459/coverage-6.5.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"]}
-        },
-        "pypi__coverage_cp38_aarch64-apple-darwin": {
-          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-          "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__coverage_cp38_aarch64-apple-darwin","build_file_content":"--\nfilegroup(\n    name = \"coverage\",\n    srcs = [\"coverage/__main__.py\"],\n    data = glob([\"coverage/*.py\", \"coverage/**/*.py\", \"coverage/*.so\"]),\n    visibility = [\"//visibility:public\"],\n)\n    ","patch_args":["---p1"],"patches":["@@rules_python~0.19.0//python/private:coverage.patch"],"sha256":"--2198ea6fc548de52adc826f62cb18554caedfb1d26548c1b7c88d8f7faa8f6ba","type":"--zip","urls":["--https://files.pythonhosted.org/packages/07/82/79fa21ceca9a9b091eb3c67e27eb648dade27b2c9e1eb23af47232a2a365/coverage-6.5.0-cp38-cp38-macosx_11_0_arm64.whl"]}
+          "attributes": {"name":"--rules_python~0.24.0~internal_deps~pypi__pep517","url":"--https://files.pythonhosted.org/packages/ee/2f/ef63e64e9429111e73d3d6cbee80591672d16f2725e648ebc52096f3d323/pep517-0.13.0-py3-none-any.whl","sha256":"--4ba4446d80aed5b5eac6509ade100bff3e7943a8489de249654a5ae9b33ee35b","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
         },
         "pypi__packaging": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
           "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__packaging","url":"--https://files.pythonhosted.org/packages/8f/7b/42582927d281d7cb035609cd3a543ffac89b74f3f4ee8e1c50914bcb57eb/packaging-22.0-py3-none-any.whl","sha256":"--957e2148ba0e1a3b282772e791ef1d8083648bc131c8ab0c1feba110ce1146c3","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
+          "attributes": {"name":"--rules_python~0.24.0~internal_deps~pypi__packaging","url":"--https://files.pythonhosted.org/packages/8f/7b/42582927d281d7cb035609cd3a543ffac89b74f3f4ee8e1c50914bcb57eb/packaging-22.0-py3-none-any.whl","sha256":"--957e2148ba0e1a3b282772e791ef1d8083648bc131c8ab0c1feba110ce1146c3","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
+        },
+        "pypi__pip_tools": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_archive",
+          "attributes": {"name":"--rules_python~0.24.0~internal_deps~pypi__pip_tools","url":"--https://files.pythonhosted.org/packages/5e/e8/f6d7d1847c7351048da870417724ace5c4506e816b38db02f4d7c675c189/pip_tools-6.12.1-py3-none-any.whl","sha256":"--f0c0c0ec57b58250afce458e2e6058b1f30a4263db895b7d72fd6311bf1dc6f7","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
         },
         "pypi__setuptools": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
           "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__setuptools","url":"--https://files.pythonhosted.org/packages/7c/5b/3d92b9f0f7ca1645cba48c080b54fe7d8b1033a4e5720091d1631c4266db/setuptools-60.10.0-py3-none-any.whl","sha256":"--782ef48d58982ddb49920c11a0c5c9c0b02e7d7d1c2ad0aa44e1a1e133051c96","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
+          "attributes": {"name":"--rules_python~0.24.0~internal_deps~pypi__setuptools","url":"--https://files.pythonhosted.org/packages/7c/5b/3d92b9f0f7ca1645cba48c080b54fe7d8b1033a4e5720091d1631c4266db/setuptools-60.10.0-py3-none-any.whl","sha256":"--782ef48d58982ddb49920c11a0c5c9c0b02e7d7d1c2ad0aa44e1a1e133051c96","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
         },
         "pypi__zipp": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
           "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__zipp","url":"--https://files.pythonhosted.org/packages/f4/50/cc72c5bcd48f6e98219fc4a88a5227e9e28b81637a99c49feba1d51f4d50/zipp-1.0.0-py2.py3-none-any.whl","sha256":"--8dda78f06bd1674bd8720df8a50bb47b6e1233c503a4eed8e7810686bde37656","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
+          "attributes": {"name":"--rules_python~0.24.0~internal_deps~pypi__zipp","url":"--https://files.pythonhosted.org/packages/f4/50/cc72c5bcd48f6e98219fc4a88a5227e9e28b81637a99c49feba1d51f4d50/zipp-1.0.0-py2.py3-none-any.whl","sha256":"--8dda78f06bd1674bd8720df8a50bb47b6e1233c503a4eed8e7810686bde37656","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
         },
         "pypi__colorama": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
           "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__colorama","url":"--https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl","sha256":"--4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
+          "attributes": {"name":"--rules_python~0.24.0~internal_deps~pypi__colorama","url":"--https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl","sha256":"--4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
         },
         "pypi__build": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
           "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__build","url":"--https://files.pythonhosted.org/packages/03/97/f58c723ff036a8d8b4d3115377c0a37ed05c1f68dd9a0d66dab5e82c5c1c/build-0.9.0-py3-none-any.whl","sha256":"--38a7a2b7a0bdc61a42a0a67509d88c71ecfc37b393baba770fae34e20929ff69","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
+          "attributes": {"name":"--rules_python~0.24.0~internal_deps~pypi__build","url":"--https://files.pythonhosted.org/packages/03/97/f58c723ff036a8d8b4d3115377c0a37ed05c1f68dd9a0d66dab5e82c5c1c/build-0.9.0-py3-none-any.whl","sha256":"--38a7a2b7a0bdc61a42a0a67509d88c71ecfc37b393baba770fae34e20929ff69","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
         },
-        "pypi__coverage_cp310_x86_64-apple-darwin": {
+        "pypi__pip": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
           "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__coverage_cp310_x86_64-apple-darwin","build_file_content":"--\nfilegroup(\n    name = \"coverage\",\n    srcs = [\"coverage/__main__.py\"],\n    data = glob([\"coverage/*.py\", \"coverage/**/*.py\", \"coverage/*.so\"]),\n    visibility = [\"//visibility:public\"],\n)\n    ","patch_args":["---p1"],"patches":["@@rules_python~0.19.0//python/private:coverage.patch"],"sha256":"--ef8674b0ee8cc11e2d574e3e2998aea5df5ab242e012286824ea3c6970580e53","type":"--zip","urls":["--https://files.pythonhosted.org/packages/c4/8d/5ec7d08f4601d2d792563fe31db5e9322c306848fec1e65ec8885927f739/coverage-6.5.0-cp310-cp310-macosx_10_9_x86_64.whl"]}
+          "attributes": {"name":"--rules_python~0.24.0~internal_deps~pypi__pip","url":"--https://files.pythonhosted.org/packages/09/bd/2410905c76ee14c62baf69e3f4aa780226c1bbfc9485731ad018e35b0cb5/pip-22.3.1-py3-none-any.whl","sha256":"--908c78e6bc29b676ede1c4d57981d490cb892eb45cd8c214ab6298125119e077","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
         },
         "pypi__installer": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
           "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__installer","url":"--https://files.pythonhosted.org/packages/bf/42/fe5f10fd0d58d5d8231a0bc39e664de09992f960597e9fbd3753f84423a3/installer-0.6.0-py3-none-any.whl","sha256":"--ae7c62d1d6158b5c096419102ad0d01fdccebf857e784cee57f94165635fe038","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
+          "attributes": {"name":"--rules_python~0.24.0~internal_deps~pypi__installer","url":"--https://files.pythonhosted.org/packages/e5/ca/1172b6638d52f2d6caa2dd262ec4c811ba59eee96d54a7701930726bce18/installer-0.7.0-py3-none-any.whl","sha256":"--05d1933f0a5ba7d8d6296bb6d5018e7c94fa473ceb10cf198a92ccea19c27b53","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
         },
         "pypi__more_itertools": {
           "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
           "ruleClassName": "http_archive",
-          "attributes": {"name":"--rules_python~0.19.0~internal_deps~pypi__more_itertools","url":"--https://files.pythonhosted.org/packages/bd/3f/c4b3dbd315e248f84c388bd4a72b131a29f123ecacc37ffb2b3834546e42/more_itertools-8.13.0-py3-none-any.whl","sha256":"--c5122bffc5f104d37c1626b8615b511f3427aa5389b94d61e5ef8236bfbc3ddb","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
+          "attributes": {"name":"--rules_python~0.24.0~internal_deps~pypi__more_itertools","url":"--https://files.pythonhosted.org/packages/bd/3f/c4b3dbd315e248f84c388bd4a72b131a29f123ecacc37ffb2b3834546e42/more_itertools-8.13.0-py3-none-any.whl","sha256":"--c5122bffc5f104d37c1626b8615b511f3427aa5389b94d61e5ef8236bfbc3ddb","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
+        },
+        "pypi__tomli": {
+          "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+          "ruleClassName": "http_archive",
+          "attributes": {"name":"--rules_python~0.24.0~internal_deps~pypi__tomli","url":"--https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl","sha256":"--939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc","type":"--zip","build_file_content":"--package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:defs.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude in /python/pip_install/tools/bazel.py\n        # to avoid non-determinism following pip install's behavior.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/* *\",\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"}
         }
       }
     }

--- a/e2e/smoke/WORKSPACE.bazel
+++ b/e2e/smoke/WORKSPACE.bazel
@@ -8,9 +8,9 @@ local_repository(
 
 http_archive(
     name = "rules_python",
-    sha256 = "8c15896f6686beb5c631a4459a3aa8392daccaab805ea899c9d14215074b60ef",
-    strip_prefix = "rules_python-0.17.3",
-    url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.17.3.tar.gz",
+    sha256 = "0a8003b044294d7840ac7d9d73eef05d6ceb682d7516781a4ec62eeb34702578",
+    strip_prefix = "rules_python-0.24.0",
+    url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.24.0.tar.gz",
 )
 
 load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")


### PR DESCRIPTION
The latest release failed to publish to BCR due to smoke test failing: https://github.com/bazelbuild/bazel-central-registry/pull/817

I was also able to reproduce the error locally; I was unable to reproduce in GitHub Actions, even though everything seems to be correctly configured.

The failure seems to be due to the `is_default` parameter, which I believe was only introduced in `rules_python` on 0.23.0 (on https://github.com/bazelbuild/rules_python/pull/1230). Hence, bump the version of `rules_python` to a recent version and update the smoke test based on current examples.